### PR TITLE
Keras model building

### DIFF
--- a/deeposlandia/keras_feature_detection.py
+++ b/deeposlandia/keras_feature_detection.py
@@ -1,0 +1,113 @@
+
+"""Design a feature detection model with Keras API
+"""
+
+import keras as K
+
+from deeposlandia.network import ConvolutionalNeuralNetwork
+
+class FeatureDetectionNetwork(ConvolutionalNeuralNetwork):
+    """
+    """
+
+    def __init__(self, network_name="mapillary", image_size=512, nb_channels=3,
+                 nb_labels=65, learning_rate=1e-4, architecture="simple"):
+        ConvolutionalNeuralNetwork.__init__(self, network_name, image_size,
+                                            nb_channels, nb_labels, learning_rate)
+        if architecture == "vgg16":
+            self.Y = self.vgg16()
+        elif architecture == "vgg19":
+            self.Y = self.vgg19()
+        elif architecture == "inception-v1":
+            self.Y = self.inception_v1()
+        elif architecture == "inception-v2":
+            self.Y = self.inception_v2()
+        elif architecture == "inception-v3":
+            self.Y = self.inception_v3()
+        elif architecture == "inception-v4":
+            self.Y = self.inception_v4()
+        elif architecture == "Xception":
+            self.Y = self.xception()
+        elif architecture == "resnet":
+            self.Y = self.resnet()
+        else:
+            self.Y = self.simple()
+
+    def output_layer(self, x, depth):
+        """Build an output layer to a neural network, as a dense layer with sigmoid activation
+        function as the point is to detect multiple labels on a single image
+
+        Parameters
+        ----------
+        x : tensor
+            Previous layer within the neural network (last hidden layer)
+        depth : integer
+            Dimension of the previous neural network layer
+
+        Returns
+        -------
+        tensor
+            2D output layer
+        """
+        y = K.layers.Dense(depth, name='output_fc')(x)
+        y = K.layers.Activation(activation='sigmoid', name='output_activation')(y)
+        return y
+
+    def simple(self):
+        """Build a simple default convolutional neural network composed of 3 convolution-maxpool
+        blocks and 1 fully-connected layer
+
+        Returns
+        -------
+        tensor
+            Output predictions, that have to be compared with ground-truth values
+        """
+        layer = self.convolution(self.X, nb_filters=16, kernel_size=7, name='conv1')
+        layer = self.maxpool(layer, pool_size=2, strides=2, name='pool1')
+        layer = self.convolution(layer, nb_filters=32, kernel_size=5, name='conv2')
+        layer = self.maxpool(layer, pool_size=2, strides=2, name='pool2')
+        layer = self.convolution(layer, nb_filters=64, kernel_size=3, name='conv3')
+        layer = self.maxpool(layer, pool_size=2, strides=2, name='pool3')
+        layer = self.flatten(layer, name='flatten1')
+        layer = self.dense(layer, depth=512, dropout_rate=0.75, name='fc1')
+        return self.output_layer(layer, depth=self._nb_labels)
+
+    def vgg16(self):
+        """
+        """
+        pass
+
+    def vgg19(self):
+        """
+        """
+        pass
+
+    def inception_v1(self):
+        """
+        """
+        pass
+    
+    def inception_v2(self):
+        """
+        """
+        pass
+
+    def inception_v3(self):
+        """
+        """
+        pass
+
+    def inception_v4(self):
+        """
+        """
+        pass
+
+    def xception(self):
+        """
+        """
+        pass
+
+    def resnet(self):
+        """
+        """
+        pass

--- a/deeposlandia/keras_feature_detection.py
+++ b/deeposlandia/keras_feature_detection.py
@@ -2,8 +2,10 @@
 """Design a feature detection model with Keras API
 """
 
-import keras as K
+import h5py
 
+import keras as K
+from keras.applications import VGG16
 from deeposlandia.network import ConvolutionalNeuralNetwork
 
 class FeatureDetectionNetwork(ConvolutionalNeuralNetwork):
@@ -101,4 +103,8 @@ class FeatureDetectionNetwork(ConvolutionalNeuralNetwork):
         tensor
             (batch_size, nb_labels)-shaped output predictions, that have to be compared with ground-truth values
         """
-        pass
+        vgg16_model = VGG16(input_tensor = self.X, include_top=False)
+        y = self.flatten(vgg16_model.output, name="flatten")
+        y = self.dense(y, 1024, dropout_rate=0.75, name="fc1")
+        y = self.dense(y, 1024, dropout_rate=0.75, name="fc2")
+        return self.output_layer(y, depth=self._nb_labels)

--- a/deeposlandia/keras_feature_detection.py
+++ b/deeposlandia/keras_feature_detection.py
@@ -67,14 +67,14 @@ class FeatureDetectionNetwork(ConvolutionalNeuralNetwork):
         tensor
             (batch_size, nb_labels)-shaped output predictions, that have to be compared with ground-truth values
         """
-        layer = self.convolution(self.X, nb_filters=16, kernel_size=7, name='conv1')
-        layer = self.maxpool(layer, pool_size=2, strides=2, name='pool1')
-        layer = self.convolution(layer, nb_filters=32, kernel_size=5, name='conv2')
-        layer = self.maxpool(layer, pool_size=2, strides=2, name='pool2')
-        layer = self.convolution(layer, nb_filters=64, kernel_size=3, name='conv3')
-        layer = self.maxpool(layer, pool_size=2, strides=2, name='pool3')
-        layer = self.flatten(layer, name='flatten1')
-        layer = self.dense(layer, depth=512, dropout_rate=0.75, name='fc1')
+        layer = self.convolution(self.X, nb_filters=16, kernel_size=7, block_name='conv1')
+        layer = self.maxpool(layer, pool_size=2, strides=2, block_name='pool1')
+        layer = self.convolution(layer, nb_filters=32, kernel_size=5, block_name='conv2')
+        layer = self.maxpool(layer, pool_size=2, strides=2, block_name='pool2')
+        layer = self.convolution(layer, nb_filters=64, kernel_size=3, block_name='conv3')
+        layer = self.maxpool(layer, pool_size=2, strides=2, block_name='pool3')
+        layer = self.flatten(layer, block_name='flatten1')
+        layer = self.dense(layer, depth=512, dropout_rate=0.75, block_name='fc1')
         return self.output_layer(layer, depth=self.nb_labels)
 
     def vgg16(self):
@@ -90,7 +90,7 @@ class FeatureDetectionNetwork(ConvolutionalNeuralNetwork):
             (batch_size, nb_labels)-shaped output predictions, that have to be compared with ground-truth values
         """
         vgg16_model = VGG16(input_tensor = self.X, include_top=False)
-        y = self.flatten(vgg16_model.output, name="flatten")
-        y = self.dense(y, 1024, dropout_rate=0.75, name="fc1")
-        y = self.dense(y, 1024, dropout_rate=0.75, name="fc2")
+        y = self.flatten(vgg16_model.output, block_name="flatten")
+        y = self.dense(y, 1024, dropout_rate=0.75, block_name="fc1")
+        y = self.dense(y, 1024, dropout_rate=0.75, block_name="fc2")
         return self.output_layer(y, depth=self.nb_labels)

--- a/deeposlandia/keras_feature_detection.py
+++ b/deeposlandia/keras_feature_detection.py
@@ -15,13 +15,13 @@ class FeatureDetectionNetwork(ConvolutionalNeuralNetwork):
 
     Attributes
     ----------
-    _network_name : str
+    network_name : str
         Name of the network
-    _image_size : integer
+    image_size : integer
         Input image size (height and width are equal)
-    _nb_channels : integer
+    nb_channels : integer
         Number of input image channels (1 for greyscaled images, 3 for RGB images)
-    _nb_labels : integer
+    nb_labels : integer
         Number of classes in the dataset glossary
     X : tensor
         (batch_size, image_size, image_size, nb_channels)-shaped input tensor; input image data
@@ -75,7 +75,7 @@ class FeatureDetectionNetwork(ConvolutionalNeuralNetwork):
         layer = self.maxpool(layer, pool_size=2, strides=2, name='pool3')
         layer = self.flatten(layer, name='flatten1')
         layer = self.dense(layer, depth=512, dropout_rate=0.75, name='fc1')
-        return self.output_layer(layer, depth=self._nb_labels)
+        return self.output_layer(layer, depth=self.nb_labels)
 
     def vgg16(self):
         """Build the structure of a convolutional neural network from input image data to the last
@@ -93,4 +93,4 @@ class FeatureDetectionNetwork(ConvolutionalNeuralNetwork):
         y = self.flatten(vgg16_model.output, name="flatten")
         y = self.dense(y, 1024, dropout_rate=0.75, name="fc1")
         y = self.dense(y, 1024, dropout_rate=0.75, name="fc2")
-        return self.output_layer(y, depth=self._nb_labels)
+        return self.output_layer(y, depth=self.nb_labels)

--- a/deeposlandia/keras_feature_detection.py
+++ b/deeposlandia/keras_feature_detection.py
@@ -31,8 +31,8 @@ class FeatureDetectionNetwork(ConvolutionalNeuralNetwork):
 
     def __init__(self, network_name="mapillary", image_size=512, nb_channels=3,
                  nb_labels=65, learning_rate=1e-4, architecture="simple"):
-        ConvolutionalNeuralNetwork.__init__(self, network_name, image_size,
-                                            nb_channels, nb_labels, learning_rate)
+        super().__init__(network_name, image_size, nb_channels,
+                         nb_labels, learning_rate)
         if architecture == "vgg16":
             self.Y = self.vgg16()
         else:

--- a/deeposlandia/keras_feature_detection.py
+++ b/deeposlandia/keras_feature_detection.py
@@ -35,20 +35,6 @@ class FeatureDetectionNetwork(ConvolutionalNeuralNetwork):
                                             nb_channels, nb_labels, learning_rate)
         if architecture == "vgg16":
             self.Y = self.vgg16()
-        elif architecture == "vgg19":
-            self.Y = self.vgg19()
-        elif architecture == "inception-v1":
-            self.Y = self.inception_v1()
-        elif architecture == "inception-v2":
-            self.Y = self.inception_v2()
-        elif architecture == "inception-v3":
-            self.Y = self.inception_v3()
-        elif architecture == "inception-v4":
-            self.Y = self.inception_v4()
-        elif architecture == "Xception":
-            self.Y = self.xception()
-        elif architecture == "resnet":
-            self.Y = self.resnet()
         else:
             self.Y = self.simple()
 

--- a/deeposlandia/keras_feature_detection.py
+++ b/deeposlandia/keras_feature_detection.py
@@ -7,7 +7,24 @@ import keras as K
 from deeposlandia.network import ConvolutionalNeuralNetwork
 
 class FeatureDetectionNetwork(ConvolutionalNeuralNetwork):
-    """
+    """Class that encapsulates feature detection network creation
+
+    Inherits from `ConvolutionalNeuralNetwork`
+
+    Attributes
+    ----------
+    _network_name : str
+        Name of the network
+    _image_size : integer
+        Input image size (height and width are equal)
+    _nb_channels : integer
+        Number of input image channels (1 for greyscaled images, 3 for RGB images)
+    _nb_labels : integer
+        Number of classes in the dataset glossary
+    X : tensor
+        (batch_size, image_size, image_size, nb_channels)-shaped input tensor; input image data
+    Y : tensor
+        (None, nb_classes)-shaped output tensor, built as the output of the last network layer
     """
 
     def __init__(self, network_name="mapillary", image_size=512, nb_channels=3,
@@ -60,7 +77,7 @@ class FeatureDetectionNetwork(ConvolutionalNeuralNetwork):
         Returns
         -------
         tensor
-            Output predictions, that have to be compared with ground-truth values
+            (batch_size, nb_labels)-shaped output predictions, that have to be compared with ground-truth values
         """
         layer = self.convolution(self.X, nb_filters=16, kernel_size=7, name='conv1')
         layer = self.maxpool(layer, pool_size=2, strides=2, name='pool1')
@@ -73,41 +90,15 @@ class FeatureDetectionNetwork(ConvolutionalNeuralNetwork):
         return self.output_layer(layer, depth=self._nb_labels)
 
     def vgg16(self):
-        """
-        """
-        pass
+        """Build the structure of a convolutional neural network from input image data to the last
+        hidden layer on the model of a similar manner than VGG-net
 
-    def vgg19(self):
-        """
-        """
-        pass
+        See: Simonyan & Zisserman, Very Deep Convolutional Networks for Large-Scale Image
+        Recognition, arXiv technical report, 2014
 
-    def inception_v1(self):
-        """
-        """
-        pass
-    
-    def inception_v2(self):
-        """
-        """
-        pass
-
-    def inception_v3(self):
-        """
-        """
-        pass
-
-    def inception_v4(self):
-        """
-        """
-        pass
-
-    def xception(self):
-        """
-        """
-        pass
-
-    def resnet(self):
-        """
+        Returns
+        -------
+        tensor
+            (batch_size, nb_labels)-shaped output predictions, that have to be compared with ground-truth values
         """
         pass

--- a/deeposlandia/keras_semantic_segmentation.py
+++ b/deeposlandia/keras_semantic_segmentation.py
@@ -30,8 +30,8 @@ class SemanticSegmentationNetwork(ConvolutionalNeuralNetwork):
 
     def __init__(self, network_name="mapillary", image_size=512, nb_channels=3,
                  nb_labels=65, learning_rate=1e-4, architecture="simple"):
-        ConvolutionalNeuralNetwork.__init__(self, network_name, image_size,
-                                            nb_channels, nb_labels, learning_rate)
+        super().__init__(network_name, image_size, nb_channels,
+                         nb_labels, learning_rate)
         self.Y = self.simple()
 
     def output_layer(self, x, depth):

--- a/deeposlandia/keras_semantic_segmentation.py
+++ b/deeposlandia/keras_semantic_segmentation.py
@@ -7,7 +7,25 @@ import keras as K
 from deeposlandia.network import ConvolutionalNeuralNetwork
 
 class SemanticSegmentationNetwork(ConvolutionalNeuralNetwork):
-    """
+    """Class that encapsulates semantic segmentation network creation
+
+    Inherits from `ConvolutionalNeuralNetwork`
+
+    Attributes
+    ----------
+    _network_name : str
+        Name of the network
+    _image_size : integer
+        Input image size (height and width are equal)
+    _nb_channels : integer
+        Number of input image channels (1 for greyscaled images, 3 for RGB images)
+    _nb_labels : integer
+        Number of classes in the dataset glossary
+    X : tensor
+        (batch_size, image_size, image_size, nb_channels)-shaped input tensor; input image data
+    Y : tensor
+        (batch_size, image_size, image_size, nb_classes)-shaped output tensor, built as the output of the
+    last network layer
     """
 
     def __init__(self, network_name="mapillary", image_size=512, nb_channels=3,
@@ -43,7 +61,8 @@ class SemanticSegmentationNetwork(ConvolutionalNeuralNetwork):
         Returns
         -------
         tensor
-            Output predictions, that have to be compared with ground-truth values
+            (batch_size, image_size, image_size, nb_labels)-shaped output predictions, that have to
+        be compared with ground-truth values
         """
         layer = self.convolution(self.X, nb_filters=32, kernel_size=3, name='conv1')
         layer = self.maxpool(layer, pool_size=2, strides=2, name='pool1')

--- a/deeposlandia/keras_semantic_segmentation.py
+++ b/deeposlandia/keras_semantic_segmentation.py
@@ -1,0 +1,57 @@
+
+"""Design a semantic segmentation model with Keras API
+"""
+
+import keras as K
+
+from deeposlandia.network import ConvolutionalNeuralNetwork
+
+class SemanticSegmentationNetwork(ConvolutionalNeuralNetwork):
+    """
+    """
+
+    def __init__(self, network_name="mapillary", image_size=512, nb_channels=3,
+                 nb_labels=65, learning_rate=1e-4, architecture="simple"):
+        ConvolutionalNeuralNetwork.__init__(self, network_name, image_size,
+                                            nb_channels, nb_labels, learning_rate)
+        self.Y = self.simple()
+
+    def output_layer(self, x, depth):
+        """Build an output layer to a neural network, as a dense layer with sigmoid activation
+        function as the point is to detect multiple labels on a single image
+
+        Parameters
+        ----------
+        x : tensor
+            Previous layer within the neural network (last hidden layer)
+        depth : integer
+            Dimension of the previous neural network layer
+
+        Returns
+        -------
+        tensor
+            2D output layer
+        """
+        y = K.layers.Conv2DTranspose(depth, kernel_size=2, padding="same", name='output_trconv')(x)
+        y = K.layers.Activation('softmax', name='output_activation')(y)
+        return y
+
+    def simple(self):
+        """Build a simple default convolutional neural network composed of 3 convolution-maxpool
+        blocks and 1 fully-connected layer
+
+        Returns
+        -------
+        tensor
+            Output predictions, that have to be compared with ground-truth values
+        """
+        layer = self.convolution(self.X, nb_filters=32, kernel_size=3, name='conv1')
+        layer = self.maxpool(layer, pool_size=2, strides=2, name='pool1')
+        layer = self.convolution(layer, nb_filters=64, kernel_size=3, name='conv2')
+        layer = self.maxpool(layer, pool_size=2, strides=2, name='pool2')
+        layer = self.convolution(layer, nb_filters=128, kernel_size=3, name='conv3')
+        layer = self.maxpool(layer, pool_size=2, strides=2, name='pool3')
+        layer = self.transposed_convolution(layer, nb_filters=128, strides=2, kernel_size=3, name="trconv1")
+        layer = self.transposed_convolution(layer, nb_filters=64, strides=2, kernel_size=3, name="trconv2")
+        layer = self.transposed_convolution(layer, nb_filters=32, strides=2, kernel_size=3, name="trconv3")
+        return self.output_layer(layer, depth=self._nb_labels)

--- a/deeposlandia/keras_semantic_segmentation.py
+++ b/deeposlandia/keras_semantic_segmentation.py
@@ -64,13 +64,13 @@ class SemanticSegmentationNetwork(ConvolutionalNeuralNetwork):
             (batch_size, image_size, image_size, nb_labels)-shaped output predictions, that have to
         be compared with ground-truth values
         """
-        layer = self.convolution(self.X, nb_filters=32, kernel_size=3, name='conv1')
-        layer = self.maxpool(layer, pool_size=2, strides=2, name='pool1')
-        layer = self.convolution(layer, nb_filters=64, kernel_size=3, name='conv2')
-        layer = self.maxpool(layer, pool_size=2, strides=2, name='pool2')
-        layer = self.convolution(layer, nb_filters=128, kernel_size=3, name='conv3')
-        layer = self.maxpool(layer, pool_size=2, strides=2, name='pool3')
-        layer = self.transposed_convolution(layer, nb_filters=128, strides=2, kernel_size=3, name="trconv1")
-        layer = self.transposed_convolution(layer, nb_filters=64, strides=2, kernel_size=3, name="trconv2")
-        layer = self.transposed_convolution(layer, nb_filters=32, strides=2, kernel_size=3, name="trconv3")
+        layer = self.convolution(self.X, nb_filters=32, kernel_size=3, block_name='conv1')
+        layer = self.maxpool(layer, pool_size=2, strides=2, block_name='pool1')
+        layer = self.convolution(layer, nb_filters=64, kernel_size=3, block_name='conv2')
+        layer = self.maxpool(layer, pool_size=2, strides=2, block_name='pool2')
+        layer = self.convolution(layer, nb_filters=128, kernel_size=3, block_name='conv3')
+        layer = self.maxpool(layer, pool_size=2, strides=2, block_name='pool3')
+        layer = self.transposed_convolution(layer, nb_filters=128, strides=2, kernel_size=3, block_name="trconv1")
+        layer = self.transposed_convolution(layer, nb_filters=64, strides=2, kernel_size=3, block_name="trconv2")
+        layer = self.transposed_convolution(layer, nb_filters=32, strides=2, kernel_size=3, block_name="trconv3")
         return self.output_layer(layer, depth=self.nb_labels)

--- a/deeposlandia/keras_semantic_segmentation.py
+++ b/deeposlandia/keras_semantic_segmentation.py
@@ -13,13 +13,13 @@ class SemanticSegmentationNetwork(ConvolutionalNeuralNetwork):
 
     Attributes
     ----------
-    _network_name : str
+    network_name : str
         Name of the network
-    _image_size : integer
+    image_size : integer
         Input image size (height and width are equal)
-    _nb_channels : integer
+    nb_channels : integer
         Number of input image channels (1 for greyscaled images, 3 for RGB images)
-    _nb_labels : integer
+    nb_labels : integer
         Number of classes in the dataset glossary
     X : tensor
         (batch_size, image_size, image_size, nb_channels)-shaped input tensor; input image data
@@ -73,4 +73,4 @@ class SemanticSegmentationNetwork(ConvolutionalNeuralNetwork):
         layer = self.transposed_convolution(layer, nb_filters=128, strides=2, kernel_size=3, name="trconv1")
         layer = self.transposed_convolution(layer, nb_filters=64, strides=2, kernel_size=3, name="trconv2")
         layer = self.transposed_convolution(layer, nb_filters=32, strides=2, kernel_size=3, name="trconv3")
-        return self.output_layer(layer, depth=self._nb_labels)
+        return self.output_layer(layer, depth=self.nb_labels)

--- a/deeposlandia/network.py
+++ b/deeposlandia/network.py
@@ -30,7 +30,7 @@ class ConvolutionalNeuralNetwork:
         self.X = K.layers.Input(shape=(image_size, image_size, nb_channels), name="input")
 
     def convolution(self, x, nb_filters, kernel_size, strides=1, padding="same",
-                    activation='relu', batch_norm=True, name=""):
+                    activation='relu', batch_norm=True, name=None):
         """Apply a convolutional layer within a neural network
 
         Use Keras API
@@ -70,7 +70,7 @@ class ConvolutionalNeuralNetwork:
         return x
 
     def transposed_convolution(self, x, nb_filters, kernel_size, strides=1,
-                               padding="same", activation='relu', batch_norm=True, name=""):
+                               padding="same", activation='relu', batch_norm=True, name=None):
         """Build a layer seen as the transpose operation of classic convolution, for a convolutional neural
         network
 
@@ -110,7 +110,7 @@ class ConvolutionalNeuralNetwork:
         x = K.layers.Activation(activation, name=name+'_activation')(x)
         return x
 
-    def maxpool(self, x, pool_size, strides=1, padding="same", name=""):
+    def maxpool(self, x, pool_size, strides=1, padding="same", name=None):
         """Apply a max pooling layer within a neural network
 
         Use Keras API
@@ -136,7 +136,7 @@ class ConvolutionalNeuralNetwork:
         """
         return K.layers.MaxPool2D(pool_size=pool_size, strides=strides, padding=padding, name=name)(x)
 
-    def dense(self, x, depth, dropout_rate=1.0, activation='relu', batch_norm=True, name=""):
+    def dense(self, x, depth, dropout_rate=1.0, activation='relu', batch_norm=True, name=None):
         """Apply a fully-connected layer within a neural network
 
         Use Keras API
@@ -170,7 +170,7 @@ class ConvolutionalNeuralNetwork:
         x = K.layers.Dropout(dropout_rate, name=name+'_dropout')(x)
         return x
 
-    def flatten(self, x, name=""):
+    def flatten(self, x, name=None):
         """Apply a flattening operation to input tensor `x`, to reduce its dimension; arises
         generally before a dense layer
 

--- a/deeposlandia/network.py
+++ b/deeposlandia/network.py
@@ -15,7 +15,7 @@ class ConvolutionalNeuralNetwork:
         self._image_size = image_size
         self._nb_channels = nb_channels
         self._nb_labels = nb_labels
-        self._X = K.layers.Input(shape=(image_size, image_size, nb_channels))
+        self.X = K.layers.Input(shape=(image_size, image_size, nb_channels))
 
     def convolution(self, x, nb_filters, kernel_size, strides=1, padding="same",
                     activation='relu', batch_norm=True):

--- a/deeposlandia/network.py
+++ b/deeposlandia/network.py
@@ -8,13 +8,13 @@ class ConvolutionalNeuralNetwork:
 
     Attributes
     ----------
-    _network_name : str
+    network_name : str
         Name of the network
-    _image_size : integer
+    image_size : integer
         Input image size (height and width are equal)
-    _nb_channels : integer
+    nb_channels : integer
         Number of input image channels (1 for greyscaled images, 3 for RGB images)
-    _nb_labels : integer
+    nb_labels : integer
         Number of classes in the dataset glossary
     X : tensor
         (batch_size, image_size, image_size, nb_channels)-shaped input tensor; input image data
@@ -23,10 +23,10 @@ class ConvolutionalNeuralNetwork:
 
     def __init__(self, network_name="mapillary", image_size=512,
                  nb_channels=3, nb_labels=65, learning_rate=1e-4):
-        self._network_name = network_name
-        self._image_size = image_size
-        self._nb_channels = nb_channels
-        self._nb_labels = nb_labels
+        self.network_name = network_name
+        self.image_size = image_size
+        self.nb_channels = nb_channels
+        self.nb_labels = nb_labels
         self.X = K.layers.Input(shape=(image_size, image_size, nb_channels), name="input")
 
     def convolution(self, x, nb_filters, kernel_size, strides=1, padding="same",

--- a/deeposlandia/network.py
+++ b/deeposlandia/network.py
@@ -5,12 +5,24 @@ import keras as K
 
 class ConvolutionalNeuralNetwork:
     """Convolutional neural network design
+
+    Attributes
+    ----------
+    _network_name : str
+        Name of the network
+    _image_size : integer
+        Input image size (height and width are equal)
+    _nb_channels : integer
+        Number of input image channels (1 for greyscaled images, 3 for RGB images)
+    _nb_labels : integer
+        Number of classes in the dataset glossary
+    X : tensor
+        (batch_size, image_size, image_size, nb_channels)-shaped input tensor; input image data
+
     """
 
     def __init__(self, network_name="mapillary", image_size=512,
                  nb_channels=3, nb_labels=65, learning_rate=1e-4):
-        """ Class constructor
-        """
         self._network_name = network_name
         self._image_size = image_size
         self._nb_channels = nb_channels

--- a/deeposlandia/network.py
+++ b/deeposlandia/network.py
@@ -18,7 +18,7 @@ class ConvolutionalNeuralNetwork:
         self.X = K.layers.Input(shape=(image_size, image_size, nb_channels))
 
     def convolution(self, x, nb_filters, kernel_size, strides=1, padding="same",
-                    activation='relu', batch_norm=True):
+                    activation='relu', batch_norm=True, name=""):
         """Apply a convolutional layer within a neural network
 
         Use Keras API
@@ -42,6 +42,8 @@ class ConvolutionalNeuralNetwork:
         batch_norm : boolean
             If True, a batch normalization process is applied on `x` tensor before activation
             layer
+        name : str
+            Convolution block name, for identification purpose
 
         Returns
         -------
@@ -49,14 +51,14 @@ class ConvolutionalNeuralNetwork:
             4D output layer
         """
         x = K.layers.Conv2D(nb_filters, kernel_size=kernel_size,
-                            strides=strides, padding='same')(x)
+                            strides=strides, padding='same', name=name+'_conv')(x)
         if batch_norm:
-            x = K.layers.BatchNormalization()(x)
-        x = K.layers.Activation(activation)(x)
+            x = K.layers.BatchNormalization(name=name+'_bn')(x)
+        x = K.layers.Activation(activation, name=name+'_activation')(x)
         return x
 
     def transposed_convolution(self, x, nb_filters, kernel_size, strides=1,
-                               padding="same", activation='relu', batch_norm=True):
+                               padding="same", activation='relu', batch_norm=True, name=""):
         """Build a layer seen as the transpose operation of classic convolution, for a convolutional neural
         network
 
@@ -81,6 +83,8 @@ class ConvolutionalNeuralNetwork:
         batch_norm : boolean
             If True, a batch normalization process is applied on `x` tensor before activation
             layer
+        name : str
+            Transposed convolution block name, for identification purpose
 
         Returns
         -------
@@ -88,13 +92,13 @@ class ConvolutionalNeuralNetwork:
             4D output layer
         """
         x = K.layers.Conv2DTranspose(nb_filters, kernel_size=kernel_size,
-                                     strides=strides, padding=padding)(x)
+                                     strides=strides, padding=padding, name=name+'_transconv')(x)
         if batch_norm:
-            x = K.layers.BatchNormalization()(x)
-        x = K.layers.Activation(activation)(x)
+            x = K.layers.BatchNormalization(name=name+'_bn')(x)
+        x = K.layers.Activation(activation, name=name+'_activation')(x)
         return x
 
-    def maxpool(self, x, pool_size, strides=1, padding="same"):
+    def maxpool(self, x, pool_size, strides=1, padding="same", name=""):
         """Apply a max pooling layer within a neural network
 
         Use Keras API
@@ -110,15 +114,17 @@ class ConvolutionalNeuralNetwork:
         padding : str
             Border pixel management ("valid" to apply convolution pixel only on image pixels, or
         "same" to replicate border pixels)
+        name : str
+            Pooling block name, for identification purpose
 
         Returns
         -------
         tensor
             4D output layer
         """
-        return K.layers.MaxPool2D(pool_size=pool_size, strides=strides, padding=padding)(x)
+        return K.layers.MaxPool2D(pool_size=pool_size, strides=strides, padding=padding, name=name)(x)
 
-    def dense(self, x, depth, dropout_rate=1.0, activation='relu', batch_norm=True):
+    def dense(self, x, depth, dropout_rate=1.0, activation='relu', batch_norm=True, name=""):
         """Apply a fully-connected layer within a neural network
 
         Use Keras API
@@ -137,17 +143,18 @@ class ConvolutionalNeuralNetwork:
         batch_norm : boolean
             If True, a batch normalization process is applied on `x` tensor before activation
             layer
+        name : str
+            Fully-connected block name, for identification purpose
 
         Returns
         -------
         tensor
             2D output layer
         """
-        x = K.layers.Flatten()(x)
-        x = K.layers.Dense(depth)(x)
+        x = K.layers.Dense(depth, name=name+'_fc')(x)
         if batch_norm:
-            x = K.layers.BatchNormalization()(x)
-        x = K.layers.Activation(activation)(x)
-        x = K.layers.Dropout(dropout_rate)(x)
+            x = K.layers.BatchNormalization(name=name+'_bn')(x)
+        x = K.layers.Activation(activation, name=name+'_activation')(x)
+        x = K.layers.Dropout(dropout_rate, name=name+'_dropout')(x)
         return x
 

--- a/deeposlandia/network.py
+++ b/deeposlandia/network.py
@@ -15,7 +15,7 @@ class ConvolutionalNeuralNetwork:
         self._image_size = image_size
         self._nb_channels = nb_channels
         self._nb_labels = nb_labels
-        self.X = K.layers.Input(shape=(image_size, image_size, nb_channels))
+        self.X = K.layers.Input(shape=(image_size, image_size, nb_channels), name="input")
 
     def convolution(self, x, nb_filters, kernel_size, strides=1, padding="same",
                     activation='relu', batch_norm=True, name=""):

--- a/deeposlandia/network.py
+++ b/deeposlandia/network.py
@@ -149,7 +149,7 @@ class ConvolutionalNeuralNetwork:
         Returns
         -------
         tensor
-            2D output layer
+            Output layer
         """
         x = K.layers.Dense(depth, name=name+'_fc')(x)
         if batch_norm:
@@ -158,3 +158,20 @@ class ConvolutionalNeuralNetwork:
         x = K.layers.Dropout(dropout_rate, name=name+'_dropout')(x)
         return x
 
+    def flatten(self, x, name=""):
+        """Apply a flattening operation to input tensor `x`, to reduce its dimension; arises
+        generally before a dense layer
+
+        Parameters
+        ----------
+        x : tensor
+            Input layer; its shapes is necessarily larger than 3
+        name : str
+            Flatten block name, for identification purpose
+
+        Returns
+        -------
+        tensor
+            2D output layer
+        """
+        return K.layers.Flatten(name=name)(x)

--- a/deeposlandia/network.py
+++ b/deeposlandia/network.py
@@ -29,8 +29,27 @@ class ConvolutionalNeuralNetwork:
         self.nb_labels = nb_labels
         self.X = K.layers.Input(shape=(image_size, image_size, nb_channels), name="input")
 
+    def layer_name(self, prefix, suffix):
+        """Concatenate prefix and suffix to build a complete layer name
+
+        Use the default Keras behavior if prefix is None
+
+        Parameters
+        ----------
+        prefix : str
+            Layer name prefix, refers to the layer block
+        suffix : str
+            Layer name suffix, refers to the layer type
+
+        Returns
+        -------
+        str
+            Complete layer name, build as prefix + suffix
+        """
+        return prefix + suffix if prefix is not None else None
+
     def convolution(self, x, nb_filters, kernel_size, strides=1, padding="same",
-                    activation='relu', batch_norm=True, name=None):
+                    activation='relu', batch_norm=True, block_name=None):
         """Apply a convolutional layer within a neural network
 
         Use Keras API
@@ -54,7 +73,7 @@ class ConvolutionalNeuralNetwork:
         batch_norm : boolean
             If True, a batch normalization process is applied on `x` tensor before activation
             layer
-        name : str
+        block_name : str
             Convolution block name, for identification purpose
 
         Returns
@@ -62,15 +81,15 @@ class ConvolutionalNeuralNetwork:
         tensor
             4D output layer
         """
-        x = K.layers.Conv2D(nb_filters, kernel_size=kernel_size,
-                            strides=strides, padding='same', name=name+'_conv')(x)
+        x = K.layers.Conv2D(nb_filters, kernel_size=kernel_size, strides=strides,
+                            padding='same', name=self.layer_name(block_name, '_conv'))(x)
         if batch_norm:
-            x = K.layers.BatchNormalization(name=name+'_bn')(x)
-        x = K.layers.Activation(activation, name=name+'_activation')(x)
+            x = K.layers.BatchNormalization(name=self.layer_name(block_name, '_bn'))(x)
+        x = K.layers.Activation(activation, name=self.layer_name(block_name, '_activation'))(x)
         return x
 
     def transposed_convolution(self, x, nb_filters, kernel_size, strides=1,
-                               padding="same", activation='relu', batch_norm=True, name=None):
+                               padding="same", activation='relu', batch_norm=True, block_name=None):
         """Build a layer seen as the transpose operation of classic convolution, for a convolutional neural
         network
 
@@ -95,7 +114,7 @@ class ConvolutionalNeuralNetwork:
         batch_norm : boolean
             If True, a batch normalization process is applied on `x` tensor before activation
             layer
-        name : str
+        block_name : str
             Transposed convolution block name, for identification purpose
 
         Returns
@@ -103,14 +122,14 @@ class ConvolutionalNeuralNetwork:
         tensor
             4D output layer
         """
-        x = K.layers.Conv2DTranspose(nb_filters, kernel_size=kernel_size,
-                                     strides=strides, padding=padding, name=name+'_transconv')(x)
+        x = K.layers.Conv2DTranspose(nb_filters, kernel_size=kernel_size, strides=strides,
+                                     padding=padding, name=self.layer_name(block_name, '_transconv'))(x)
         if batch_norm:
-            x = K.layers.BatchNormalization(name=name+'_bn')(x)
-        x = K.layers.Activation(activation, name=name+'_activation')(x)
+            x = K.layers.BatchNormalization(name=self.layer_name(block_name, '_bn'))(x)
+        x = K.layers.Activation(activation, name=self.layer_name(block_name, '_activation'))(x)
         return x
 
-    def maxpool(self, x, pool_size, strides=1, padding="same", name=None):
+    def maxpool(self, x, pool_size, strides=1, padding="same", block_name=None):
         """Apply a max pooling layer within a neural network
 
         Use Keras API
@@ -126,7 +145,7 @@ class ConvolutionalNeuralNetwork:
         padding : str
             Border pixel management ("valid" to apply convolution pixel only on image pixels, or
         "same" to replicate border pixels)
-        name : str
+        block_name : str
             Pooling block name, for identification purpose
 
         Returns
@@ -134,9 +153,9 @@ class ConvolutionalNeuralNetwork:
         tensor
             4D output layer
         """
-        return K.layers.MaxPool2D(pool_size=pool_size, strides=strides, padding=padding, name=name)(x)
+        return K.layers.MaxPool2D(pool_size=pool_size, strides=strides, padding=padding, name=block_name)(x)
 
-    def dense(self, x, depth, dropout_rate=1.0, activation='relu', batch_norm=True, name=None):
+    def dense(self, x, depth, dropout_rate=1.0, activation='relu', batch_norm=True, block_name=None):
         """Apply a fully-connected layer within a neural network
 
         Use Keras API
@@ -155,7 +174,7 @@ class ConvolutionalNeuralNetwork:
         batch_norm : boolean
             If True, a batch normalization process is applied on `x` tensor before activation
             layer
-        name : str
+        block_name : str
             Fully-connected block name, for identification purpose
 
         Returns
@@ -163,14 +182,14 @@ class ConvolutionalNeuralNetwork:
         tensor
             Output layer
         """
-        x = K.layers.Dense(depth, name=name+'_fc')(x)
+        x = K.layers.Dense(depth, name=self.layer_name(block_name, '_fc'))(x)
         if batch_norm:
-            x = K.layers.BatchNormalization(name=name+'_bn')(x)
-        x = K.layers.Activation(activation, name=name+'_activation')(x)
-        x = K.layers.Dropout(dropout_rate, name=name+'_dropout')(x)
+            x = K.layers.BatchNormalization(name=self.layer_name(block_name, '_bn'))(x)
+        x = K.layers.Activation(activation, name=self.layer_name(block_name, '_activation'))(x)
+        x = K.layers.Dropout(dropout_rate, name=self.layer_name(block_name, '_dropout'))(x)
         return x
 
-    def flatten(self, x, name=None):
+    def flatten(self, x, block_name=None):
         """Apply a flattening operation to input tensor `x`, to reduce its dimension; arises
         generally before a dense layer
 
@@ -178,7 +197,7 @@ class ConvolutionalNeuralNetwork:
         ----------
         x : tensor
             Input layer; its shapes is necessarily larger than 3
-        name : str
+        block_name : str
             Flatten block name, for identification purpose
 
         Returns
@@ -186,4 +205,4 @@ class ConvolutionalNeuralNetwork:
         tensor
             2D output layer
         """
-        return K.layers.Flatten(name=name)(x)
+        return K.layers.Flatten(name=block_name)(x)

--- a/tests/test_cnn_model.py
+++ b/tests/test_cnn_model.py
@@ -14,7 +14,7 @@ def test_convolution_shape():
     strides = 2
     cnn = ConvolutionalNeuralNetwork("test", image_size)
     y = cnn.convolution(cnn.X, nb_filters=depth,
-                        kernel_size=3, strides=strides, name="convtest")
+                        kernel_size=3, strides=strides, block_name="convtest")
     m = Model(cnn.X, y)
     output_shape = m.output_shape
     assert len(output_shape) == 4
@@ -31,7 +31,7 @@ def test_transposed_convolution_shape():
     cnn = ConvolutionalNeuralNetwork("test", image_size)
     y = cnn.transposed_convolution(cnn.X, nb_filters=depth,
                                    kernel_size=kernel_size, strides=strides,
-                                   name="transconvtest")
+                                   block_name="transconvtest")
     m = Model(cnn.X, y)
     output_shape = m.output_shape
     assert len(output_shape) == 4
@@ -46,7 +46,7 @@ def test_maxpooling_shape():
     psize = 2
     strides = 2
     cnn = ConvolutionalNeuralNetwork("test", image_size, nb_channels)
-    y = cnn.maxpool(cnn.X, pool_size=psize, strides=strides, name="pooltest")
+    y = cnn.maxpool(cnn.X, pool_size=psize, strides=strides, block_name="pooltest")
     m = Model(cnn.X, y)
     output_shape = m.output_shape
     assert len(output_shape) == 4
@@ -59,7 +59,7 @@ def test_dense_shape():
     image_size = 64
     depth = 8
     cnn = ConvolutionalNeuralNetwork("test", image_size)
-    y = cnn.dense(cnn.X, depth=depth, name="fctest")
+    y = cnn.dense(cnn.X, depth=depth, block_name="fctest")
     m = Model(cnn.X, y)
     output_shape = m.output_shape
     assert len(output_shape) == 4
@@ -72,8 +72,26 @@ def test_flatten_shape():
     image_size = 64
     nb_channels = 3
     cnn = ConvolutionalNeuralNetwork("test", image_size=image_size, nb_channels=nb_channels)
-    y = cnn.flatten(cnn.X, name="flattentest")
+    y = cnn.flatten(cnn.X, block_name="flattentest")
     m = Model(cnn.X, y)
     output_shape = m.output_shape
     assert len(output_shape) == 2
     assert output_shape[1] == image_size * image_size * nb_channels
+
+def test_layer_name():
+    """Test the convolution operation through its output layer shape
+
+    """
+    image_size = 64
+    depth = 8
+    strides = 1
+    cnn = ConvolutionalNeuralNetwork("test", image_size)
+    y = cnn.convolution(cnn.X, nb_filters=depth,
+                        kernel_size=3, strides=strides)
+    y = cnn.convolution(y, nb_filters=depth,
+                        kernel_size=3, strides=strides)
+    m = Model(cnn.X, y)
+    output_shape = m.output_shape
+    assert ([l.name for l in m.layers[1:]] ==
+            ['conv2d_1', 'batch_normalization_1', 'activation_1',
+             'conv2d_2', 'batch_normalization_2', 'activation_2'])

--- a/tests/test_cnn_model.py
+++ b/tests/test_cnn_model.py
@@ -1,6 +1,8 @@
 """Unit test related to the simple layer creation
 """
 
+from keras.models import Model
+
 from deeposlandia.network import ConvolutionalNeuralNetwork
 
 def test_convolution_shape():
@@ -13,8 +15,10 @@ def test_convolution_shape():
     cnn = ConvolutionalNeuralNetwork("test", image_size)
     y = cnn.convolution(cnn.X, nb_filters=depth,
                         kernel_size=3, strides=strides, name="convtest")
-    assert len(y.shape) == 4
-    assert y.shape[1:] == (image_size//strides, image_size//strides, depth)
+    m = Model(cnn.X, y)
+    output_shape = m.output_shape
+    assert len(output_shape) == 4
+    assert output_shape[1:] == (image_size//strides, image_size//strides, depth)
 
 def test_transposed_convolution_shape():
     """Test the transposed convolution operation through its output layer shape
@@ -28,8 +32,10 @@ def test_transposed_convolution_shape():
     y = cnn.transposed_convolution(cnn.X, nb_filters=depth,
                                    kernel_size=kernel_size, strides=strides,
                                    name="transconvtest")
-    assert len(y.shape) == 4
-    assert y.shape[1:] == (image_size//strides, image_size//strides, depth)
+    m = Model(cnn.X, y)
+    output_shape = m.output_shape
+    assert len(output_shape) == 4
+    assert output_shape[1:] == (image_size*strides, image_size*strides, depth)
 
 def test_maxpooling_shape():
     """Test the max pooling operation through its output layer shape
@@ -41,8 +47,10 @@ def test_maxpooling_shape():
     strides = 2
     cnn = ConvolutionalNeuralNetwork("test", image_size, nb_channels)
     y = cnn.maxpool(cnn.X, pool_size=psize, strides=strides, name="pooltest")
-    assert len(y.shape) == 4
-    assert y.shape[1:] == (image_size//strides, image_size//strides, nb_channels)
+    m = Model(cnn.X, y)
+    output_shape = m.output_shape
+    assert len(output_shape) == 4
+    assert output_shape[1:] == (image_size//strides, image_size//strides, nb_channels)
 
 def test_dense_shape():
     """Test the fully-connected layer through its output shape
@@ -52,5 +60,20 @@ def test_dense_shape():
     depth = 8
     cnn = ConvolutionalNeuralNetwork("test", image_size)
     y = cnn.dense(cnn.X, depth=depth, name="fctest")
-    assert len(y.shape) == 2
-    assert y.shape[1] == depth
+    m = Model(cnn.X, y)
+    output_shape = m.output_shape
+    assert len(output_shape) == 4
+    assert output_shape[1:] == (image_size, image_size, depth)
+
+def test_flatten_shape():
+    """Test the flattening layer through its output shape
+
+    """
+    image_size = 64
+    nb_channels = 3
+    cnn = ConvolutionalNeuralNetwork("test", image_size=image_size, nb_channels=nb_channels)
+    y = cnn.flatten(cnn.X, name="flattentest")
+    m = Model(cnn.X, y)
+    output_shape = m.output_shape
+    assert len(output_shape) == 2
+    assert output_shape[1] == image_size * image_size * nb_channels

--- a/tests/test_cnn_model.py
+++ b/tests/test_cnn_model.py
@@ -11,8 +11,8 @@ def test_convolution_shape():
     depth = 8
     strides = 2
     cnn = ConvolutionalNeuralNetwork("test", image_size)
-    y = cnn.convolution(cnn._X, nb_filters=depth,
-                        kernel_size=3, strides=strides)
+    y = cnn.convolution(cnn.X, nb_filters=depth,
+                        kernel_size=3, strides=strides, name="convtest")
     assert len(y.shape) == 4
     assert y.shape[1:] == (image_size//strides, image_size//strides, depth)
 
@@ -25,8 +25,9 @@ def test_transposed_convolution_shape():
     kernel_size = 3
     strides = 2
     cnn = ConvolutionalNeuralNetwork("test", image_size)
-    y = cnn.transposed_convolution(cnn._X, nb_filters=depth,
-                                   kernel_size=kernel_size, strides=strides)
+    y = cnn.transposed_convolution(cnn.X, nb_filters=depth,
+                                   kernel_size=kernel_size, strides=strides,
+                                   name="transconvtest")
     assert len(y.shape) == 4
     assert y.shape[1:] == (image_size//strides, image_size//strides, depth)
 
@@ -39,7 +40,7 @@ def test_maxpooling_shape():
     psize = 2
     strides = 2
     cnn = ConvolutionalNeuralNetwork("test", image_size, nb_channels)
-    y = cnn.maxpool(cnn._X, pool_size=psize, strides=strides)
+    y = cnn.maxpool(cnn.X, pool_size=psize, strides=strides, name="pooltest")
     assert len(y.shape) == 4
     assert y.shape[1:] == (image_size//strides, image_size//strides, nb_channels)
 
@@ -50,7 +51,6 @@ def test_dense_shape():
     image_size = 64
     depth = 8
     cnn = ConvolutionalNeuralNetwork("test", image_size)
-    y = cnn.dense(cnn._X, depth=depth)
+    y = cnn.dense(cnn.X, depth=depth, name="fctest")
     assert len(y.shape) == 2
     assert y.shape[1] == depth
-    

--- a/tests/test_feature_detection.py
+++ b/tests/test_feature_detection.py
@@ -1,4 +1,4 @@
-"""Unit test related to feature detection model instanciation
+"""Unit test related to the feature detection model
 """
 
 from keras.models import Model
@@ -6,7 +6,7 @@ from keras.models import Model
 from deeposlandia.keras_feature_detection import FeatureDetectionNetwork
 
 def test_simple_network_architecture():
-    """Test the instanciation of a simple feature detection network
+    """Test a simple feature detection network
 
     """
     IMAGE_SIZE = 64
@@ -23,7 +23,7 @@ def test_simple_network_architecture():
     assert output_shape[1] == NB_LABELS
 
 def test_vgg16_network_architecture():
-    """Test the instanciation of a VGG16-inspired feature detection network
+    """Test a VGG16-inspired feature detection network
 
     """
     IMAGE_SIZE = 224

--- a/tests/test_feature_detection.py
+++ b/tests/test_feature_detection.py
@@ -5,7 +5,7 @@ from keras.models import Model
 
 from deeposlandia.keras_feature_detection import FeatureDetectionNetwork
 
-def test_network_instanciation():
+def test_simple_network_architecture():
     """Test the instanciation of a simple feature detection network
 
     """
@@ -14,6 +14,24 @@ def test_network_instanciation():
     NB_LABELS = 3
     net = FeatureDetectionNetwork("fd_test", image_size=IMAGE_SIZE,
                                   nb_channels=NB_CHANNELS, nb_labels=NB_LABELS)
+    m = Model(net.X, net.Y)
+    input_shape = m.input_shape
+    output_shape = m.output_shape
+    assert len(input_shape) == 4
+    assert input_shape[1:] == (IMAGE_SIZE, IMAGE_SIZE, NB_CHANNELS)
+    assert len(output_shape) == 2
+    assert output_shape[1] == NB_LABELS
+
+def test_vgg16_network_architecture():
+    """Test the instanciation of a VGG16-inspired feature detection network
+
+    """
+    IMAGE_SIZE = 224
+    NB_CHANNELS = 3
+    NB_LABELS = 3
+    net = FeatureDetectionNetwork("fd_test", image_size=IMAGE_SIZE,
+                                  nb_channels=NB_CHANNELS, nb_labels=NB_LABELS,
+                                  architecture="vgg16")
     m = Model(net.X, net.Y)
     input_shape = m.input_shape
     output_shape = m.output_shape

--- a/tests/test_feature_detection.py
+++ b/tests/test_feature_detection.py
@@ -1,0 +1,23 @@
+"""Unit test related to feature detection model instanciation
+"""
+
+from keras.models import Model
+
+from deeposlandia.keras_feature_detection import FeatureDetectionNetwork
+
+def test_network_instanciation():
+    """Test the instanciation of a simple feature detection network
+
+    """
+    IMAGE_SIZE = 64
+    NB_CHANNELS = 3
+    NB_LABELS = 3
+    net = FeatureDetectionNetwork("fd_test", image_size=IMAGE_SIZE,
+                                  nb_channels=NB_CHANNELS, nb_labels=NB_LABELS)
+    m = Model(net.X, net.Y)
+    input_shape = m.input_shape
+    output_shape = m.output_shape
+    assert len(input_shape) == 4
+    assert input_shape[1:] == (IMAGE_SIZE, IMAGE_SIZE, NB_CHANNELS)
+    assert len(output_shape) == 2
+    assert output_shape[1] == NB_LABELS

--- a/tests/test_semantic_segmentation.py
+++ b/tests/test_semantic_segmentation.py
@@ -1,4 +1,4 @@
-"""Unit test related to semantic segmentation model instanciation
+"""Unit test related to the semantic segmentation model
 """
 
 from keras.models import Model
@@ -6,7 +6,7 @@ from keras.models import Model
 from deeposlandia.keras_semantic_segmentation import SemanticSegmentationNetwork
 
 def test_network_instanciation():
-    """Test the instanciation of a simple feature detection network
+    """Test a simple feature detection network
 
     """
     IMAGE_SIZE = 64

--- a/tests/test_semantic_segmentation.py
+++ b/tests/test_semantic_segmentation.py
@@ -1,0 +1,23 @@
+"""Unit test related to semantic segmentation model instanciation
+"""
+
+from keras.models import Model
+
+from deeposlandia.keras_semantic_segmentation import SemanticSegmentationNetwork
+
+def test_network_instanciation():
+    """Test the instanciation of a simple feature detection network
+
+    """
+    IMAGE_SIZE = 64
+    NB_CHANNELS = 3
+    NB_LABELS = 3
+    net = SemanticSegmentationNetwork("ss_test", image_size=IMAGE_SIZE,
+                                      nb_channels=NB_CHANNELS, nb_labels=NB_LABELS)
+    m = Model(net.X, net.Y)
+    input_shape = m.input_shape
+    output_shape = m.output_shape
+    assert len(input_shape) == 4
+    assert input_shape[1:] == (IMAGE_SIZE, IMAGE_SIZE, NB_CHANNELS)
+    assert len(output_shape) == 4
+    assert output_shape[1:] == (IMAGE_SIZE, IMAGE_SIZE, NB_LABELS)


### PR DESCRIPTION
Implement dedicated classes to build feature detection and semantic segmentation architectures. It is crucial to notice that the produced classes correspond to **architectures** instead of **models** for now. We will use the Keras API to easily create models, by considering `Network.X` and `Network.Y` : 
```
net = FeatureDetectionNetworl(image_size=224, nb_channels=3, nb_labels=65)
model = keras.models.Model(net.X, net.Y)
model.compile(...)
model.summary() # Gives the whole architecture of the network, built during the instanciation of `net`
```

In this PR, a first example of state-of-the-art model architecture reusing is also provided with `VGG16` network (see *Simonyan, 2015*). For more details, see `architecture` attribute of class `FeatureDetectionNetwork` and `SemanticSegmentation`.

Some unit tests come with these new features.