### PR TITLE
training: fix the learning rate implementation

### DIFF
--- a/deeposlandia/keras_feature_detection.py
+++ b/deeposlandia/keras_feature_detection.py
@@ -30,9 +30,8 @@ class FeatureDetectionNetwork(ConvolutionalNeuralNetwork):
     """
 
     def __init__(self, network_name="mapillary", image_size=512, nb_channels=3,
-                 nb_labels=65, learning_rate=1e-4, architecture="simple"):
-        super().__init__(network_name, image_size, nb_channels,
-                         nb_labels, learning_rate)
+                 nb_labels=65, architecture="simple"):
+        super().__init__(network_name, image_size, nb_channels, nb_labels)
         if architecture == "vgg16":
             self.Y = self.vgg16()
         else:

--- a/deeposlandia/keras_semantic_segmentation.py
+++ b/deeposlandia/keras_semantic_segmentation.py
@@ -29,9 +29,8 @@ class SemanticSegmentationNetwork(ConvolutionalNeuralNetwork):
     """
 
     def __init__(self, network_name="mapillary", image_size=512, nb_channels=3,
-                 nb_labels=65, learning_rate=1e-4, architecture="simple"):
-        super().__init__(network_name, image_size, nb_channels,
-                         nb_labels, learning_rate)
+                 nb_labels=65, architecture="simple"):
+        super().__init__(network_name, image_size, nb_channels, nb_labels)
         self.Y = self.simple()
 
     def output_layer(self, x, depth):

--- a/deeposlandia/kerastrain.py
+++ b/deeposlandia/kerastrain.py
@@ -10,6 +10,7 @@ from datetime import datetime
 
 from keras import backend
 from keras.models import Model
+from keras.optimizers import Adam
 
 from deeposlandia import generator, utils
 from deeposlandia.keras_feature_detection import FeatureDetectionNetwork
@@ -80,12 +81,14 @@ def add_hyperparameters(parser):
                         default=0,
                         help=("Number of training epochs (one epoch means "
                               "scanning each training image once)"))
-    parser.add_argument('-l', '--learning-rate',
-                        nargs="+",
-                        default=[0.001, 300, 0.95],
+    parser.add_argument('-L', '--learning-rate', 
+                        default=0.001,
                         type=float,
-                        help=("List of learning rate components (starting LR, "
-                              "decay steps and decay rate)"))
+                        help=("Starting learning rate"))
+    parser.add_argument('-l', '--learning-rate-decay',
+                        default=0.00001,
+                        type=float,
+                        help=("Learning rate decay"))
     parser.add_argument('-s', '--image-size',
                         default=256,
                         type=int,
@@ -139,7 +142,8 @@ if __name__=='__main__':
     # Instance name (name + image size + network size + batch_size
     # + aggregate? + dropout + learning_rate)
     instance_args = [args.name, args.image_size, args.network, args.batch_size,
-                     aggregate_value, args.dropout, utils.list_to_str(args.learning_rate)]
+                     aggregate_value, args.dropout,
+                     args.learning_rate, args.learning_rate_decay]
     instance_name = utils.list_to_str(instance_args, "_")
 
     # Data gathering
@@ -185,7 +189,6 @@ if __name__=='__main__':
                                       image_size=args.image_size,
                                       nb_channels=3,
                                       nb_labels=nb_labels,
-                                      learning_rate=args.learning_rate,
                                       architecture=args.network)
         loss_function = "binary_crossentropy"
     elif args.model == "semantic_segmentation":
@@ -193,7 +196,6 @@ if __name__=='__main__':
                                           image_size=args.image_size,
                                           nb_channels=nb_labels,
                                           nb_labels=len(train_config["labels"]),
-                                          learning_rate=args.learning_rate,
                                           architecture=args.network)
         loss_function = "categorical_crossentropy"
     else:
@@ -201,8 +203,9 @@ if __name__=='__main__':
                             "or 'semantic_segmentation'."))
         sys.exit(1)
     model = Model(net.X, net.Y)
+    opt = Adam(lr=args.learning_rate, decay=args.learning_rate_decay)
     model.compile(loss=loss_function,
-                  optimizer='adam',
+                  optimizer=opt,
                   metrics=['acc', 'mae'])
     model.summary()
 

--- a/deeposlandia/network.py
+++ b/deeposlandia/network.py
@@ -22,7 +22,7 @@ class ConvolutionalNeuralNetwork:
     """
 
     def __init__(self, network_name="mapillary", image_size=512,
-                 nb_channels=3, nb_labels=65, learning_rate=1e-4):
+                 nb_channels=3, nb_labels=65):
         self.network_name = network_name
         self.image_size = image_size
         self.nb_channels = nb_channels


### PR DESCRIPTION
Before this PR, the learning rate was still implemented following the TensorFlow version of the code. The way the learning rate is considered is now updated: it is introduced as a parameter of the optimizer function, instead of being an attribute of the `ConvolutionalNeuralNetwork` class.

As a direct consequence of this treatment, we do not consider a parsed list of argument any more: a `-L` argument handles the starting learning rate, and a `-l` argument manages the learning rate decay rate.

This PR fixes the issue #60.