### PR TITLE
Model inference

### DIFF
--- a/deeposlandia/inference.py
+++ b/deeposlandia/inference.py
@@ -1,0 +1,213 @@
+
+"""Inference on deep learning model previously trained
+
+* Build the instance name
+
+* Load one (or more) image(s) from the file system:
+
+* Load a trained model starting from the instance name
+
+* Make label predictions on the test image(s)
+
+* Produce a result: for instance, only predicted labels
+
+Example of program call, that will infers labels on all files from
+̀path_to_images/shapes_00000.png` to `path_to_images/shapes_00009.png`::
+
+    python deeposlandia/inference.py -D shapes -i path_to_images/shapes_0000*.png
+
+"""
+
+import argparse
+import glob
+import numpy as np
+import os
+from PIL import Image
+import sys
+
+from keras.models import Model
+
+from deeposlandia import utils
+from deeposlandia.keras_feature_detection import FeatureDetectionNetwork
+from deeposlandia.keras_semantic_segmentation import SemanticSegmentationNetwork
+
+
+def add_program_arguments(parser):
+    """Add instance-specific arguments from the command line
+
+    Parameters
+    ----------
+    parser : argparse.ArgumentParser
+        Input parser
+
+    Returns
+    -------
+    argparse.ArgumentParser
+        Modified parser, with additional arguments
+    """
+    parser.add_argument('-D', '--dataset',
+                        required=True,
+                        help="Dataset type (either mapillary or shapes)")
+    parser.add_argument('-i', '--image-paths',
+                        required=True,
+                        nargs='+',
+                        help="Path of the image on the file system")
+    parser.add_argument('-M', '--model',
+                        default="feature_detection",
+                        help=("Type of model to train, either "
+                              "'feature_detection' or 'semantic_segmentation'"))
+    parser.add_argument('-p', '--datapath',
+                        default="./data",
+                        help="Relative path towards data directory")
+    return parser
+
+def add_instance_arguments(parser):
+    """Add instance-specific arguments from the command line
+
+    Parameters
+    ----------
+    parser : argparse.ArgumentParser
+        Input parser
+
+    Returns
+    -------
+    argparse.ArgumentParser
+        Modified parser, with additional arguments
+    """
+    parser.add_argument('-a', '--aggregate-label', action='store_true',
+                        help="Aggregate labels with respect to their categories")
+    parser.add_argument('-b', '--batch-size',
+                        type=int,
+                        default=None,
+                        help=("Number of images that must be contained "
+                              "into a single batch"))
+    parser.add_argument('-d', '--dropout',
+                        type=float,
+                        default=None,
+                        help=("Percentage of dropped out neurons "
+                              "during training"))
+    parser.add_argument('-L', '--learning-rate', 
+                        default=None,
+                        type=float,
+                        help=("Starting learning rate"))
+    parser.add_argument('-l', '--learning-rate-decay',
+                        default=None,
+                        type=float,
+                        help=("Learning rate decay"))
+    parser.add_argument('-n', '--name',
+                        default=None,
+                        help=("Model name that will be used for results, "
+                              "checkout and graph storage on file system"))
+    parser.add_argument('-N', '--network',
+                        default=None,
+                        help=("Neural network size, either 'simple', 'vgg' or "
+                              "'inception' ('simple' refers to 3 conv/pool "
+                              "blocks and 1 fully-connected layer; the others "
+                              "refer to state-of-the-art networks)"))
+    return parser
+
+
+if __name__ == '__main__':
+
+    program_description = ("Infer labels on one (or more) image file(s) "
+                           "from a trained deep neural network")
+    parser = argparse.ArgumentParser(description=program_description)
+    parser = add_program_arguments(parser)
+    parser = add_instance_arguments(parser)
+    args = parser.parse_args()
+
+    image_paths = [item for sublist in [glob.glob(f) for f in args.image_paths]
+                   for item in sublist]
+    x_test = []
+    for image_path in image_paths:
+        image = Image.open(image_path)
+        image_size = image.size[0]
+        if image.size[0] != image.size[1]:
+            utils.logger.error(("One of the parsed images "
+                                "has non-squared dimensions."))
+            sys.exit(1)
+        x_test.append(np.array(image))
+    x_test = np.array(x_test)
+    
+    aggregate_value = "full" if not args.aggregate_label else "aggregated"
+    instance_args = [args.name, image_size, args.network, args.batch_size,
+                     aggregate_value, args.dropout,
+                     args.learning_rate, args.learning_rate_decay]
+    instance_name = utils.list_to_str(instance_args, "_")
+
+    input_folder = utils.prepare_input_folder(args.datapath, args.dataset)
+    prepro_folder = utils.prepare_preprocessed_folder(args.datapath,
+                                                      args.dataset,
+                                                      image_size,
+                                                      aggregate_value)
+
+    print( prepro_folder['training_config'] )
+    if os.path.isfile(prepro_folder["training_config"]):
+        train_config = utils.read_config(prepro_folder["training_config"])
+        label_ids = [x['id'] for x in train_config['labels']
+                     if x['is_evaluate']]
+        nb_labels = len(label_ids)
+    else:
+        utils.logger.error(("There is no valid data with the specified parameters. "
+                           "Please generate a valid dataset "
+                            "before calling the program."))
+        sys.exit(1)
+
+    # Model creation
+    if args.model == "feature_detection":
+        net = FeatureDetectionNetwork(network_name=instance_name,
+                                      image_size=image_size,
+                                      nb_labels=nb_labels,
+                                      architecture=args.network)
+        loss_function = "binary_crossentropy"
+    elif args.model == "semantic_segmentation":
+        net = SemanticSegmentationNetwork(network_name=instance_name,
+                                          image_size=image_size,
+                                          nb_labels=nb_labels,
+                                          architecture=args.network)
+        loss_function = "categorical_crossentropy"
+    else:
+        utils.logger.error(("Unrecognized model. Please enter 'feature_detection' "
+                            "or 'semantic_segmentation'."))
+        sys.exit(1)
+    model = Model(net.X, net.Y)
+
+    if any([arg is None for arg in instance_args]):
+        utils.logger.info("Some arguments are None, the best model is considered.")
+        output_folder = utils.prepare_output_folder(args.datapath,
+                                                    args.dataset,
+                                                    args.model)
+        checkpoints = os.listdir(output_folder)
+        if len(checkpoints) > 0:
+            model_checkpoint = max(checkpoints)
+            checkpoint_complete_path = os.path.join(output_folder,
+                                                    model_checkpoint)
+            model.load_weights(checkpoint_complete_path)
+            utils.logger.info(("Model weights have been recovered from {}"
+                               "").format(checkpoint_complete_path))
+        else:
+            utils.logger.info(("No available trained model for this image size"
+                               " with optimized hyperparameters. The "
+                               "inference will be done on an untrained model"))
+    else:
+        utils.logger.info("All instance arguments are filled out.")
+        output_folder = utils.prepare_output_folder(args.datapath,
+                                                    args.dataset,
+                                                    args.model,
+                                                    instance_name)
+        model_checkpoint = "best-model-" + str(image_size) + ".h5"
+        checkpoint_complete_path = os.path.join(output_folder,
+                                                model_checkpoint)
+        if os.path.isfile(checkpoint_complete_path):
+            model.load_weights(checkpoint_complete_path)
+            utils.logger.info(("Model weights have been recovered from {}"
+                               "").format(checkpoint_complete_path))
+        else:
+            utils.logger.info(("No available checkpoint for this configuration. "
+                               "The model will be trained from scratch."))
+
+    y_raw_pred = model.predict(x_test)
+    y_pred = np.round(y_raw_pred).astype(np.uint8)
+    utils.logger.info("Predicted labels:")
+    for image, prediction in zip(image_paths, y_pred.tolist()):
+        utils.logger.info("{}: {}".format(image, prediction))

--- a/deeposlandia/inference.py
+++ b/deeposlandia/inference.py
@@ -177,7 +177,8 @@ if __name__ == '__main__':
         output_folder = utils.prepare_output_folder(args.datapath,
                                                     args.dataset,
                                                     args.model)
-        checkpoints = os.listdir(output_folder)
+        checkpoints = [item for item in os.listdir(output_folder)
+                       if os.path.isfile(os.path.join(output_folder, item))]
         if len(checkpoints) > 0:
             model_checkpoint = max(checkpoints)
             checkpoint_complete_path = os.path.join(output_folder,

--- a/deeposlandia/kerastrain.py
+++ b/deeposlandia/kerastrain.py
@@ -143,7 +143,6 @@ if __name__=='__main__':
     instance_name = utils.list_to_str(instance_args, "_")
 
     # Data path and repository management
-    input_folder = utils.prepare_input_folder(args.datapath, args.dataset)
     prepro_folder = utils.prepare_preprocessed_folder(args.datapath, args.dataset,
                                                       args.image_size,
                                                       aggregate_value)

--- a/deeposlandia/kerastrain.py
+++ b/deeposlandia/kerastrain.py
@@ -143,19 +143,23 @@ if __name__=='__main__':
     instance_name = utils.list_to_str(instance_args, "_")
 
     # Data path and repository management
-    folders = utils.prepare_folders(args.datapath, args.dataset, aggregate_value,
-                                    args.image_size, args.model, instance_name)
+    input_folder = utils.prepare_input_folder(args.datapath, args.dataset)
+    prepro_folder = utils.prepare_preprocessed_folder(args.datapath, args.dataset,
+                                                      args.image_size,
+                                                      aggregate_value)
+    output_folder = utils.prepare_output_folder(args.datapath, args.dataset,
+                                                args.model, instance_name)
 
     # Data gathering
     train_seed = int(datetime.now().timestamp())
-    if (os.path.isfile(folders["training_config"]) and os.path.isfile(folders["validation_config"])
-        and os.path.isfile(folders["testing_config"])):
-        train_config = utils.read_config(folders["training_config"])
+    if (os.path.isfile(prepro_folder["training_config"]) and os.path.isfile(prepro_folder["validation_config"])
+        and os.path.isfile(prepro_folder["testing_config"])):
+        train_config = utils.read_config(prepro_folder["training_config"])
         label_ids = [x['id'] for x in train_config['labels'] if x['is_evaluate']]
         train_generator = generator.create_generator(
             args.dataset,
             args.model,
-            folders["prepro_training"],
+            prepro_folder["training"],
             args.image_size,
             args.batch_size,
             label_ids,
@@ -163,7 +167,7 @@ if __name__=='__main__':
         validation_generator = generator.create_generator(
             args.dataset,
             args.model,
-            folders["prepro_validation"],
+            prepro_folder["validation"],
             args.image_size,
             args.batch_size,
             label_ids,
@@ -171,7 +175,7 @@ if __name__=='__main__':
         test_generator = generator.create_generator(
             args.dataset,
             args.model,
-            folders["prepro_testing"],
+            prepro_folder["testing"],
             args.image_size,
             args.batch_size,
             label_ids,
@@ -214,9 +218,8 @@ if __name__=='__main__':
     VAL_STEPS = args.nb_validation_image // args.batch_size
     TEST_STEPS = args.nb_testing_image // args.batch_size
 
-    checkpoint_path = os.path.join(folders["output"], "checkpoints", instance_name)
-    if os.path.isdir(checkpoint_path):
-        checkpoints = os.listdir(checkpoint_path)
+    if os.path.isdir(output_folder):
+        checkpoints = os.listdir(output_folder)
         if len(checkpoints) > 0:
             model_checkpoint = max(checkpoints)
             trained_model_epoch = int(model_checkpoint[-5:-3])
@@ -233,9 +236,7 @@ if __name__=='__main__':
                            "The model will be trained from scratch."))
         trained_model_epoch = 0
 
-    checkpoint_filename = os.path.join(folders["output"],
-                                       "checkpoints",
-                                       instance_name,
+    checkpoint_filename = os.path.join(output_folder,
                                        "checkpoint-epoch-{epoch:03d}.h5")
     checkpoints = callbacks.ModelCheckpoint(
         checkpoint_filename,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -129,3 +129,8 @@ def shapes_temp_dir(tmpdir_factory):
     tmpdir_factory.mktemp('shapes/labels', numbered=False)
     tmpdir_factory.mktemp('shapes/checkpoints', numbered=False)
     return shapes_subdir
+
+@pytest.fixture(scope='session')
+def datapath_repo(tmpdir_factory):
+    datapath_subdir = tmpdir_factory.mktemp('datapath', numbered=False)
+    return datapath_subdir

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -1,0 +1,76 @@
+"""Unit test related to data folder organization
+"""
+
+import numpy as np
+import os
+
+from deeposlandia.utils import (prepare_input_folder,
+                                prepare_preprocessed_folder,
+                                prepare_output_folder)
+
+def test_input_folder(datapath_repo):
+    """Test the existence of the raw dataset directory when using
+    ̀utils.prepare_input_folder`
+
+    """
+    datapath = str(datapath_repo)
+    dataset = "shapes"
+    prepare_input_folder(datapath, dataset)
+    assert os.path.isdir(os.path.join(datapath, dataset, "input"))
+
+def test_preprocessed_folder(datapath_repo):
+    """Test the creation of the preprocessed data repositories, by checking the
+    full expected tree, *i.e.* considering training, validation and testing
+    repositories within an instance-specific folder, and images and labels
+    repositories wihtin each of these subrepositories
+
+    """
+    datapath = str(datapath_repo)
+    dataset = "shapes"
+    image_size = 64
+    aggregate = "full"
+    prepare_preprocessed_folder(datapath, dataset, image_size, aggregate)
+    assert os.path.isdir(os.path.join(datapath, dataset, "preprocessed"))
+    assert os.path.isdir(os.path.join(datapath, dataset, "preprocessed",
+                                      str(image_size) + "_" + aggregate))
+    assert os.path.isdir(os.path.join(datapath, dataset, "preprocessed",
+                                      str(image_size) + "_" + aggregate,
+                                      "training"))
+    assert os.path.isdir(os.path.join(datapath, dataset, "preprocessed",
+                                      str(image_size) + "_" + aggregate,
+                                      "training", "images"))
+    assert os.path.isdir(os.path.join(datapath, dataset, "preprocessed",
+                                      str(image_size) + "_" + aggregate,
+                                      "training", "labels"))
+    assert os.path.isdir(os.path.join(datapath, dataset, "preprocessed",
+                                      str(image_size) + "_" + aggregate,
+                                      "validation"))
+    assert os.path.isdir(os.path.join(datapath, dataset, "preprocessed",
+                                      str(image_size) + "_" + aggregate,
+                                      "validation", "images"))
+    assert os.path.isdir(os.path.join(datapath, dataset, "preprocessed",
+                                      str(image_size) + "_" + aggregate,
+                                      "validation", "labels"))
+    assert os.path.isdir(os.path.join(datapath, dataset, "preprocessed",
+                                      str(image_size) + "_" + aggregate,
+                                      "testing"))
+    assert os.path.isdir(os.path.join(datapath, dataset, "preprocessed",
+                                      str(image_size) + "_" + aggregate,
+                                      "testing", "images"))
+    
+def test_output_folder(datapath_repo):
+    """Test the creation of the dataset output repository, by checking the full
+    expected tree, *i.e.* until the instance-specific checkpoint folder
+
+    """
+    datapath = str(datapath_repo)
+    dataset = "shapes"
+    model = "feature_detection"
+    instance_name = "test_instance"
+    prepare_output_folder(datapath, dataset, model, instance_name)
+    assert os.path.isdir(os.path.join(datapath, dataset, "output"))
+    assert os.path.isdir(os.path.join(datapath, dataset, "output", model))
+    assert os.path.isdir(os.path.join(datapath, dataset, "output", model,
+                                      "checkpoints"))
+    assert os.path.isdir(os.path.join(datapath, dataset, "output", model,
+                                      "checkpoints", instance_name))


### PR DESCRIPTION
This PR introduces a new module that will make the inference easier in further developments (for instance, in a web app).

Until now, inference was done only after training a model. It was possible to do inference only, by passing 0 to `nb_epochs`, or alternatively a number smaller than the checkpoint training step, if a backup exists. This was quite unpractical, as the program arguments are training-focused.

Here we can predict labels on a given image by simply entering the following command (as an example):
```
python deeposlandia/inference.py -D dataset -i path_to_image/image_name.png
```

Additionally, the `prepare_folders` function has been splitted into three more precise functions:
- `prepare_input_folder`, which is called during dataset generation (*cf* `deeposlandia/datagen.py`).
- `prepare_prepro_folder` which is called during dataset generation and training process: such directories are filled during the former and the images that they contain are scanned during the latter.
- `prepare_output_folder` which is called when results are produced, either during training process (model backup creations) or during inference (model backup recovering).
