### PR TITLE
Inference fix

### DIFF
--- a/deeposlandia/datagen.py
+++ b/deeposlandia/datagen.py
@@ -57,7 +57,7 @@ def add_instance_arguments(parser):
                         help=("Number of training images"))
     parser.add_argument('-v', '--nb-validation-image',
                         type=int,
-                        default=200,
+                        default=2000,
                         help=("Number of validation images"))
     return parser
 

--- a/deeposlandia/inference.py
+++ b/deeposlandia/inference.py
@@ -194,22 +194,21 @@ if __name__ == '__main__':
         sys.exit(1)
 
     if any([arg is None for arg in instance_args]):
-        utils.logger.info("Some arguments are None, the best model is considered.")
+        utils.logger.info(("Some arguments are None, "
+                           "the best model is considered."))
         output_folder = utils.prepare_output_folder(args.datapath,
                                                     args.dataset,
                                                     args.model)
-        instance_path = os.path.join(output_folder, "best-instance-" + str(image_size) + ".json")
+        instance_filename = "best-instance-" + str(image_size) + ".json"
+        instance_path = os.path.join(output_folder, instance_filename)
         dropout, network = utils.recover_instance(instance_path)
         model = init_model(args.model, instance_name, image_size, nb_labels, dropout, network)
-        checkpoints = [item for item in os.listdir(output_folder)
-                       if os.path.isfile(os.path.join(output_folder, item))]
-        if len(checkpoints) > 0:
-            model_checkpoint = max(checkpoints)
-            checkpoint_complete_path = os.path.join(output_folder,
-                                                    model_checkpoint)
-            model.load_weights(checkpoint_complete_path)
+        checkpoint_filename = "best-model-" + str(image_size) + ".h5"
+        checkpoint_full_path = os.path.join(output_folder, checkpoint_filename)
+        if os.path.isfile(checkpoint_full_path):
+            model.load_weights(checkpoint_full_path)
             utils.logger.info(("Model weights have been recovered from {}"
-                               "").format(checkpoint_complete_path))
+                               "").format(checkpoint_full_path))
         else:
             utils.logger.info(("No available trained model for this image size"
                                " with optimized hyperparameters. The "
@@ -222,13 +221,14 @@ if __name__ == '__main__':
                                                     instance_name)
         model = init_model(args.model, instance_name, image_size,
                            nb_labels, args.dropout, args.network)
-        model_checkpoint = "best-model-" + str(image_size) + ".h5"
-        checkpoint_complete_path = os.path.join(output_folder,
-                                                model_checkpoint)
-        if os.path.isfile(checkpoint_complete_path):
-            model.load_weights(checkpoint_complete_path)
+        checkpoints = [item for item in os.listdir(output_folder)
+                       if os.path.isfile(os.path.join(output_folder, item))]
+        if len(checkpoints) > 0:
+            model_checkpoint = max(checkpoints)
+            checkpoint_full_path = os.path.join(output_folder, model_checkpoint)
+            model.load_weights(checkpoint_full_path)
             utils.logger.info(("Model weights have been recovered from {}"
-                               "").format(checkpoint_complete_path))
+                               "").format(checkpoint_full_path))
         else:
             utils.logger.info(("No available checkpoint for this configuration. "
                                "The model will be trained from scratch."))

--- a/deeposlandia/utils.py
+++ b/deeposlandia/utils.py
@@ -207,3 +207,21 @@ def prepare_output_folder(datapath, dataset, model, instance_name=None):
                                      model, "checkpoints")
     os.makedirs(output_folder, exist_ok=True)
     return output_folder
+
+def recover_instance(instance_path):
+    """Recover instance specification for model design, *i.e.* dropout rate and network
+    architecture
+
+    Parameters
+    ----------
+    instance_path : str
+        Path of the instance specifications on the file system
+
+    Returns
+    -------
+    tuple
+        Instance dropout and network architecture
+    """
+    with open(instance_path) as fobj:
+        instance = json.load(fobj)
+    return instance["dropout"], instance["network"]


### PR DESCRIPTION
The parameterization during inference process is not working as it should. Two cases are handled:
- instance parameters are not set, and consequently we use the best model for the current image size, stored in `<datapath>/<dataset>/output/<problem>/checkpoints/`. In such a case a backup filename is built, and we must check that this file does exist.
- instance parameters are set (all of them!), and consequently a model is recovered from the dedicated instance repository, *i.e.*  `<datapath>/<dataset>/output/<problem>/checkpoints/<instance>/`. In this second case, the verification is on the subdir content.