### PR TITLE
Metric design

### DIFF
--- a/deeposlandia/metrics.py
+++ b/deeposlandia/metrics.py
@@ -1,0 +1,97 @@
+"""Metrics for measuring machine learning algorithm performances
+"""
+
+from keras import backend
+
+def iou(actual, predicted):
+    """Compute Intersection over Union statistic (i.e. Jaccard Index)
+
+    See https://en.wikipedia.org/wiki/Jaccard_index
+
+    Parameters
+    ----------
+    actual : list
+        Ground-truth labels
+    predicted : list
+        Predicted labels
+
+    Returns
+    -------
+    float
+        Intersection over Union value
+    """
+    actual = backend.flatten(actual)
+    predicted = backend.flatten(predicted)
+    intersection = backend.sum(actual * predicted)
+    union = backend.sum(actual) + backend.sum(predicted) - intersection
+    print(intersection, type(intersection))
+    print(union, type(union))
+    return 1. * intersection / union
+
+def iou_loss(actual, predicted):
+    """Loss function based on the Intersection over Union (IoU) statistic
+
+    IoU is comprised between 0 and 1, as a consequence the function is set as
+    `f(.)=1-IoU(.)`: the loss has to be minimized, and is comprised between 0
+    and 1 too
+
+    Parameters
+    ----------
+    actual : list
+        Ground-truth labels
+    predicted : list
+        Predicted labels
+
+    Returns
+    -------
+    float
+        Intersection-over-Union-based loss
+    """
+    return 1. - iou(actual, predicted)
+
+def dice_coef(actual, predicted, eps=1e-3):
+    """Dice coef
+
+    See https://en.wikipedia.org/wiki/S%C3%B8rensen%E2%80%93Dice_coefficient
+    Examples at:
+      -
+    https://github.com/jocicmarko/ultrasound-nerve-segmentation/blob/master/train.py#L23
+      -
+    https://github.com/ZFTurbo/ZF_UNET_224_Pretrained_Model/blob/master/zf_unet_224_model.py#L36
+
+
+    Parameters
+    ----------
+    actual : list
+        Ground-truth labels
+    predicted : list
+        Predicted labels
+    eps : float
+        Epsilon value to add numerical stability
+
+    Returns
+    -------
+    float
+        Dice coef value
+    """
+    y_true_f = backend.flatten(actual)
+    y_pred_f = backend.flatten(predicted)
+    intersection = backend.sum(y_true_f * y_pred_f)
+    return (2. * intersection + eps) / (backend.sum(y_true_f) + backend.sum(y_pred_f) + eps)
+
+def dice_coef_loss(actual, predicted):
+    """
+    Parameters
+    ----------
+    actual : list
+        Ground-truth labels
+    predicted : list
+        Predicted labels
+
+    Returns
+    -------
+    float
+        Dice-coef-based loss
+    """
+    return -dice_coef(actual, predicted)
+

--- a/deeposlandia/paramoptim.py
+++ b/deeposlandia/paramoptim.py
@@ -300,13 +300,17 @@ def run_model(train_generator, validation_generator, dl_model, output_folder,
                                         patience=10,
                                         verbose=1,
                                         mode='max')
+    csv_logger = callbacks.CSVLogger(os.path.join(output_folder,
+                                                  'training_metrics.csv'))
+
     hist = model.fit_generator(train_generator,
                                epochs=nb_epochs,
                                initial_epoch=trained_model_epoch,
                                steps_per_epoch=steps,
                                validation_data=validation_generator,
                                validation_steps=val_steps,
-                               callbacks=[checkpoint, earlystop, terminate_on_nan])
+                               callbacks=[checkpoint, earlystop,
+                                          terminate_on_nan, csv_logger])
     ref_metric = max(hist.history.get("val_acc", [np.nan]))
     return {'model': model, 'val_acc': ref_metric,
             'batch_size': batch_size, 'network': network, 'dropout': dropout,

--- a/deeposlandia/train.py
+++ b/deeposlandia/train.py
@@ -334,13 +334,16 @@ if __name__=='__main__':
                                         patience=10,
                                         verbose=1,
                                         mode='max')
+    csv_logger = callbacks.CSVLogger(os.path.join(output_folder,
+                                                  'training_metrics.csv'))
 
     hist = model.fit_generator(train_generator,
                                epochs=args.nb_epochs,
                                steps_per_epoch=STEPS,
                                validation_data=validation_generator,
                                validation_steps=VAL_STEPS,
-                               callbacks=[checkpoint, terminate_on_nan, earlystop],
+                               callbacks=[checkpoint, terminate_on_nan,
+                                          earlystop, csv_logger],
                                initial_epoch=trained_model_epoch)
     metrics = {"epoch": hist.epoch,
                "metrics": hist.history,

--- a/deeposlandia/train.py
+++ b/deeposlandia/train.py
@@ -12,7 +12,7 @@ from keras import backend, callbacks
 from keras.models import Model
 from keras.optimizers import Adam
 
-from deeposlandia import generator, utils
+from deeposlandia import generator, metrics, utils
 from deeposlandia.feature_detection import FeatureDetectionNetwork
 from deeposlandia.semantic_segmentation import SemanticSegmentationNetwork
 
@@ -123,96 +123,6 @@ def add_training_arguments(parser):
                         help=("Number of validation images"))
     return parser
 
-def iou(actual, predicted):
-    """Compute Intersection over Union statistic (i.e. Jaccard Index)
-
-    See https://en.wikipedia.org/wiki/Jaccard_index
-
-    Parameters
-    ----------
-    actual : list
-        Ground-truth labels
-    predicted : list
-        Predicted labels
-
-    Returns
-    -------
-    float
-        Intersection over Union value
-    """
-    actual = backend.flatten(actual)
-    predicted = backend.flatten(predicted)
-    intersection = backend.sum(actual * predicted)
-    union = backend.sum(actual) + backend.sum(predicted) - intersection
-    return 1. * intersection / union
-
-def iou_loss(actual, predicted):
-    """Loss function based on the Intersection over Union (IoU) statistic
-
-    IoU is comprised between 0 and 1, as a consequence the function is set as
-    `f(.)=1-IoU(.)`: the loss has to be minimized, and is comprised between 0
-    and 1 too
-
-    Parameters
-    ----------
-    actual : list
-        Ground-truth labels
-    predicted : list
-        Predicted labels
-
-    Returns
-    -------
-    float
-        Intersection-over-Union-based loss
-    """
-    return 1. - iou(actual, predicted)
-
-def dice_coef(actual, predicted, eps=1e-3):
-    """Dice coef
-
-    See https://en.wikipedia.org/wiki/S%C3%B8rensen%E2%80%93Dice_coefficient
-    Examples at:
-      -
-    https://github.com/jocicmarko/ultrasound-nerve-segmentation/blob/master/train.py#L23
-      -
-    https://github.com/ZFTurbo/ZF_UNET_224_Pretrained_Model/blob/master/zf_unet_224_model.py#L36
-
-
-    Parameters
-    ----------
-    actual : list
-        Ground-truth labels
-    predicted : list
-        Predicted labels
-    eps : float
-        Epsilon value to add numerical stability
-
-    Returns
-    -------
-    float
-        Dice coef value
-    """
-    y_true_f = backend.flatten(actual)
-    y_pred_f = backend.flatten(predicted)
-    intersection = backend.sum(y_true_f * y_pred_f)
-    return (2. * intersection + eps) / (backend.sum(y_true_f) + backend.sum(y_pred_f) + eps)
-
-def dice_coef_loss(actual, predicted):
-    """
-    Parameters
-    ----------
-    actual : list
-        Ground-truth labels
-    predicted : list
-        Predicted labels
-
-    Returns
-    -------
-    float
-        Dice-coef-based loss
-    """
-    return -dice_coef(actual, predicted)
-
 if __name__=='__main__':
 
     # Parse command-line arguments
@@ -293,7 +203,7 @@ if __name__=='__main__':
         sys.exit(1)
     model = Model(net.X, net.Y)
     opt = Adam(lr=args.learning_rate, decay=args.learning_rate_decay)
-    metrics = [iou, dice_coef, "acc"]
+    metrics = [metrics.iou, metrics.dice_coef, "acc"]
     model.compile(loss=loss_function,
                   optimizer=opt,
                   metrics=metrics)

--- a/deeposlandia/train.py
+++ b/deeposlandia/train.py
@@ -123,6 +123,96 @@ def add_training_arguments(parser):
                         help=("Number of validation images"))
     return parser
 
+def iou(actual, predicted):
+    """Compute Intersection over Union statistic (i.e. Jaccard Index)
+
+    See https://en.wikipedia.org/wiki/Jaccard_index
+
+    Parameters
+    ----------
+    actual : list
+        Ground-truth labels
+    predicted : list
+        Predicted labels
+
+    Returns
+    -------
+    float
+        Intersection over Union value
+    """
+    actual = backend.flatten(actual)
+    predicted = backend.flatten(predicted)
+    intersection = backend.sum(actual * predicted)
+    union = backend.sum(actual) + backend.sum(predicted) - intersection
+    return 1. * intersection / union
+
+def iou_loss(actual, predicted):
+    """Loss function based on the Intersection over Union (IoU) statistic
+
+    IoU is comprised between 0 and 1, as a consequence the function is set as
+    `f(.)=1-IoU(.)`: the loss has to be minimized, and is comprised between 0
+    and 1 too
+
+    Parameters
+    ----------
+    actual : list
+        Ground-truth labels
+    predicted : list
+        Predicted labels
+
+    Returns
+    -------
+    float
+        Intersection-over-Union-based loss
+    """
+    return 1. - iou(actual, predicted)
+
+def dice_coef(actual, predicted, eps=1e-3):
+    """Dice coef
+
+    See https://en.wikipedia.org/wiki/S%C3%B8rensen%E2%80%93Dice_coefficient
+    Examples at:
+      -
+    https://github.com/jocicmarko/ultrasound-nerve-segmentation/blob/master/train.py#L23
+      -
+    https://github.com/ZFTurbo/ZF_UNET_224_Pretrained_Model/blob/master/zf_unet_224_model.py#L36
+
+
+    Parameters
+    ----------
+    actual : list
+        Ground-truth labels
+    predicted : list
+        Predicted labels
+    eps : float
+        Epsilon value to add numerical stability
+
+    Returns
+    -------
+    float
+        Dice coef value
+    """
+    y_true_f = backend.flatten(actual)
+    y_pred_f = backend.flatten(predicted)
+    intersection = backend.sum(y_true_f * y_pred_f)
+    return (2. * intersection + eps) / (backend.sum(y_true_f) + backend.sum(y_pred_f) + eps)
+
+def dice_coef_loss(actual, predicted):
+    """
+    Parameters
+    ----------
+    actual : list
+        Ground-truth labels
+    predicted : list
+        Predicted labels
+
+    Returns
+    -------
+    float
+        Dice-coef-based loss
+    """
+    return -dice_coef(actual, predicted)
+
 if __name__=='__main__':
 
     # Parse command-line arguments
@@ -203,9 +293,10 @@ if __name__=='__main__':
         sys.exit(1)
     model = Model(net.X, net.Y)
     opt = Adam(lr=args.learning_rate, decay=args.learning_rate_decay)
+    metrics = [iou, dice_coef, "acc"]
     model.compile(loss=loss_function,
                   optimizer=opt,
-                  metrics=['acc'])
+                  metrics=metrics)
 
     # Model training
     STEPS = args.nb_training_image // args.batch_size
@@ -232,7 +323,7 @@ if __name__=='__main__':
                                        "checkpoint-epoch-{epoch:03d}.h5")
     checkpoint = callbacks.ModelCheckpoint(
         checkpoint_filename,
-        monitor='val_acc',
+        monitor='val_loss',
         verbose=0,
         save_best_only=True,
         save_weights_only=False,


### PR DESCRIPTION
This PR aims at introducing new metrics to follow the training performance. We design Intersection-over-Union (IoU) as in https://en.wikipedia.org/wiki/Jaccard_index, and the Dice coefficient, as in https://en.wikipedia.org/wiki/S%C3%B8rensen%E2%80%93Dice_coefficient.

Two additional methods are added to consider metric-based losses, however there are not used for now. The used loss functions are still binary cross-entropy for feature detection and categorical cross-entropy for semantic segmentation, as they are very popular in the state-of-the-art... Further investigations could be done in the future on this particular question, however we can consider that these loss functions are satisfying.

All the metrics are logger in a `.csv` file in instance-related repositories, so as to keep track of each training process.

This PR fixes issue #21 .