### PR TITLE
Update CLIs

### DIFF
--- a/deeposlandia/datagen.py
+++ b/deeposlandia/datagen.py
@@ -59,15 +59,15 @@ def add_instance_arguments(parser):
                         help=("Desired size of images (width = height)"))
     parser.add_argument('-T', '--nb-testing-image',
                         type=int,
-                        default=5000,
+                        default=0,
                         help=("Number of testing images"))
     parser.add_argument('-t', '--nb-training-image',
                         type=int,
-                        default=18000,
+                        default=0,
                         help=("Number of training images"))
     parser.add_argument('-v', '--nb-validation-image',
                         type=int,
-                        default=2000,
+                        default=0,
                         help=("Number of validation images"))
     return parser
 
@@ -115,43 +115,46 @@ if __name__=='__main__':
         sys.exit(1)
 
     # Dataset populating/loading (depends on the existence of a specification file)
-    if os.path.isfile(prepro_folder["training_config"]):
-        train_dataset.load(prepro_folder["training_config"],
-                           args.nb_training_image)
-    else:
-        logger.info(("No existing configuration file for this dataset. "
-                     "Create %s." % prepro_folder['training_config']))
-        input_image_dir = os.path.join(input_folder, "training")
-        train_dataset.populate(prepro_folder["training"], input_image_dir,
-                               nb_images=args.nb_training_image,
-                               aggregate=args.aggregate_label)
-        train_dataset.save(prepro_folder["training_config"])
+    if args.nb_training_image > 0:
+        if os.path.isfile(prepro_folder["training_config"]):
+            train_dataset.load(prepro_folder["training_config"],
+                               args.nb_training_image)
+        else:
+            logger.info(("No existing configuration file for this dataset. "
+                         "Create %s." % prepro_folder['training_config']))
+            input_image_dir = os.path.join(input_folder, "training")
+            train_dataset.populate(prepro_folder["training"], input_image_dir,
+                                   nb_images=args.nb_training_image,
+                                   aggregate=args.aggregate_label)
+            train_dataset.save(prepro_folder["training_config"])
 
-    if os.path.isfile(prepro_folder["validation_config"]):
-        validation_dataset.load(prepro_folder["validation_config"],
-                                args.nb_validation_image)
-    else:
-        logger.info(("No existing configuration file for this dataset. "
-                     "Create %s." % prepro_folder['validation_config']))
-        input_image_dir = os.path.join(input_folder, "validation")
-        validation_dataset.populate(prepro_folder["validation"],
-                                    input_image_dir,
-                                    nb_images=args.nb_validation_image,
-                                    aggregate=args.aggregate_label)
-        validation_dataset.save(prepro_folder["validation_config"])
+    if args.nb_validation_image > 0:
+        if os.path.isfile(prepro_folder["validation_config"]):
+            validation_dataset.load(prepro_folder["validation_config"],
+                                    args.nb_validation_image)
+        else:
+            logger.info(("No existing configuration file for this dataset. "
+                         "Create %s." % prepro_folder['validation_config']))
+            input_image_dir = os.path.join(input_folder, "validation")
+            validation_dataset.populate(prepro_folder["validation"],
+                                        input_image_dir,
+                                        nb_images=args.nb_validation_image,
+                                        aggregate=args.aggregate_label)
+            validation_dataset.save(prepro_folder["validation_config"])
 
-    if os.path.isfile(prepro_folder["testing_config"]):
-        test_dataset.load(prepro_folder["testing_config"], args.nb_testing_image)
-    else:
-        logger.info(("No existing configuration file for this dataset. "
-                     "Create %s." % prepro_folder['testing_config']))
-        input_image_dir = os.path.join(input_folder, "testing")
-        test_dataset.populate(prepro_folder["testing"],
-                              input_image_dir,
-                              nb_images=args.nb_testing_image,
-                              aggregate=args.aggregate_label,
-                              labelling=False)
-        test_dataset.save(prepro_folder["testing_config"])
+    if args.nb_testing_image > 0:
+        if os.path.isfile(prepro_folder["testing_config"]):
+            test_dataset.load(prepro_folder["testing_config"], args.nb_testing_image)
+        else:
+            logger.info(("No existing configuration file for this dataset. "
+                         "Create %s." % prepro_folder['testing_config']))
+            input_image_dir = os.path.join(input_folder, "testing")
+            test_dataset.populate(prepro_folder["testing"],
+                                  input_image_dir,
+                                  nb_images=args.nb_testing_image,
+                                  aggregate=args.aggregate_label,
+                                  labelling=False)
+            test_dataset.save(prepro_folder["testing_config"])
 
     glossary = pd.DataFrame(train_dataset.labels)
     glossary["popularity"] = train_dataset.get_label_popularity()

--- a/deeposlandia/paramoptim.py
+++ b/deeposlandia/paramoptim.py
@@ -124,17 +124,13 @@ def add_training_arguments(parser):
                         default=0,
                         help=("Number of training epochs (one epoch means "
                               "scanning each training image once)"))
-    parser.add_argument('-ii', '--nb-testing-image',
+    parser.add_argument('-t', '--nb-training-image',
                         type=int,
-                        default=5000,
+                        default=0,
                         help=("Number of training images"))
-    parser.add_argument('-it', '--nb-training-image',
+    parser.add_argument('-v', '--nb-validation-image',
                         type=int,
-                        default=18000,
-                        help=("Number of training images"))
-    parser.add_argument('-iv', '--nb-validation-image',
-                        type=int,
-                        default=2000,
+                        default=0,
                         help=("Number of validation images"))
     return parser
 
@@ -158,7 +154,7 @@ def get_data(folders, dataset, model, image_size, batch_size):
     Returns
     -------
     tuple
-        Number of labels in the dataset, as well as training, validation and testing data generators
+        Number of labels in the dataset, as well as training and validation data generators
 
     """
     # Data gathering
@@ -192,23 +188,8 @@ def get_data(folders, dataset, model, image_size, batch_size):
                       "parameters. Please generate a valid dataset "
                       "before calling the training program."))
         sys.exit(1)
-    if os.path.isfile(folders["testing_config"]):
-        test_generator = generator.create_generator(
-            dataset,
-            model,
-            folders["testing"],
-            image_size,
-            batch_size,
-            train_config["labels"],
-            inference=True,
-            seed=SEED)
-    else:
-        logger.error(("There is no training data with the given "
-                      "parameters. Please generate a valid dataset "
-                      "before calling the training program."))
-        sys.exit(1)
     nb_labels = len(label_ids)
-    return nb_labels, train_generator, validation_generator, test_generator
+    return nb_labels, train_generator, validation_generator
 
 
 def run_model(train_generator, validation_generator, dl_model, output_folder,
@@ -360,11 +341,11 @@ if __name__ == '__main__':
                                                           args.dataset,
                                                           args.image_size,
                                                           aggregate_value)
-        nb_labels, train_gen, valid_gen, test_gen = get_data(prepro_folder,
-                                                             args.dataset,
-                                                             args.model,
-                                                             model_input_size,
-                                                             batch_size)
+        nb_labels, train_gen, valid_gen = get_data(prepro_folder,
+                                                   args.dataset,
+                                                   args.model,
+                                                   model_input_size,
+                                                   batch_size)
         for parameters in itertools.product(args.dropout,
                                             args.network,
                                             args.learning_rate,

--- a/deeposlandia/train.py
+++ b/deeposlandia/train.py
@@ -115,17 +115,13 @@ def add_training_arguments(parser):
     argparse.ArgumentParser
         Modified parser, with additional arguments
     """
-    parser.add_argument('-ii', '--nb-testing-image',
+    parser.add_argument('-t', '--nb-training-image',
                         type=int,
-                        default=5000,
+                        default=0,
                         help=("Number of training images"))
-    parser.add_argument('-it', '--nb-training-image',
+    parser.add_argument('-v', '--nb-validation-image',
                         type=int,
-                        default=18000,
-                        help=("Number of training images"))
-    parser.add_argument('-iv', '--nb-validation-image',
-                        type=int,
-                        default=2000,
+                        default=0,
                         help=("Number of validation images"))
     return parser
 
@@ -186,22 +182,6 @@ if __name__=='__main__':
                       "before calling the training program."))
         sys.exit(1)
 
-    if os.path.isfile(prepro_folder["testing_config"]):
-        test_generator = generator.create_generator(
-            args.dataset,
-            args.model,
-            prepro_folder["testing"],
-            model_input_size,
-            args.batch_size,
-            train_config['labels'],
-            inference=True,
-            seed=SEED)
-    else:
-        logger.error(("There is no testing data with the given "
-                      "parameters. Please generate a valid dataset "
-                      "before calling the training program."))
-        sys.exit(1)
-
     nb_labels = len(label_ids)
 
     if args.model == "feature_detection":
@@ -234,7 +214,6 @@ if __name__=='__main__':
     # Model training
     STEPS = args.nb_training_image // args.batch_size
     VAL_STEPS = args.nb_validation_image // args.batch_size
-    TEST_STEPS = args.nb_testing_image // args.batch_size
 
     output_folder = utils.prepare_output_folder(args.datapath, args.dataset,
                                                 args.model, instance_name)


### PR DESCRIPTION
This PR harmonizes the different CLIs that compose the project, *i.e.* `datagen`, `train` and `paramoptim` programs. These programs have used different arguments until now for the image amounts, this point is fixed. Additionally, we modify the default number of images, to force user to specify a strictly positive quantity (default to 0 for training, validation and testing images).
Finally, the mentions of a testing dataset have been removed from `train.py` and `paramoptim.py` as they are obsolete now.