### PR TITLE
Dataset test updates

### DIFF
--- a/config.ini.sample
+++ b/config.ini.sample
@@ -1,6 +1,9 @@
 [status]
 status = dev
 
+[running]
+processes = 1
+
 [symlink]
 predicted = /path/to/predicted/images/
 shapes = /path/to/shape/dataset/

--- a/deeposlandia/__init__.py
+++ b/deeposlandia/__init__.py
@@ -1,7 +1,10 @@
 """Deeposlandia package
 """
 
+from configparser import ConfigParser
 import logging
+import os
+import sys
 
 import daiquiri
 
@@ -13,3 +16,12 @@ daiquiri.setup(level=logging.INFO,outputs=(
              "%(funcName)s : %(color)s%(message)s%(color_stop)s"))),
 ))
 logger = daiquiri.getLogger("root")
+
+_DEEPOSL_CONFIG = os.getenv('DEEPOSL_CONFIG')
+_DEEPOSL_CONFIG = _DEEPOSL_CONFIG if _DEEPOSL_CONFIG is not None else "config.ini"
+config = ConfigParser()
+if os.path.isfile(_DEEPOSL_CONFIG):
+    config.read(_DEEPOSL_CONFIG)
+else:
+    logger.error("No file config.ini!")
+    sys.exit(1)

--- a/deeposlandia/datagen.py
+++ b/deeposlandia/datagen.py
@@ -20,7 +20,7 @@ import sys
 import daiquiri
 import pandas as pd
 
-from deeposlandia import utils
+from deeposlandia import config, utils
 from deeposlandia.datasets import AVAILABLE_DATASETS
 from deeposlandia.datasets.mapillary import MapillaryDataset
 from deeposlandia.datasets.aerial import AerialDataset
@@ -125,7 +125,8 @@ if __name__=='__main__':
             input_image_dir = os.path.join(input_folder, "training")
             train_dataset.populate(prepro_folder["training"], input_image_dir,
                                    nb_images=args.nb_training_image,
-                                   aggregate=args.aggregate_label)
+                                   aggregate=args.aggregate_label,
+                                   nb_processes=int(config.get("running", "processes")))
             train_dataset.save(prepro_folder["training_config"])
 
     if args.nb_validation_image > 0:
@@ -139,7 +140,8 @@ if __name__=='__main__':
             validation_dataset.populate(prepro_folder["validation"],
                                         input_image_dir,
                                         nb_images=args.nb_validation_image,
-                                        aggregate=args.aggregate_label)
+                                        aggregate=args.aggregate_label,
+                                        nb_processes=int(config.get("running", "processes")))
             validation_dataset.save(prepro_folder["validation_config"])
 
     if args.nb_testing_image > 0:
@@ -153,7 +155,8 @@ if __name__=='__main__':
                                   input_image_dir,
                                   nb_images=args.nb_testing_image,
                                   aggregate=args.aggregate_label,
-                                  labelling=False)
+                                  labelling=False,
+                                  nb_processes=int(config.get("running", "processes")))
             test_dataset.save(prepro_folder["testing_config"])
 
     glossary = pd.DataFrame(train_dataset.labels)

--- a/deeposlandia/webapp/main.py
+++ b/deeposlandia/webapp/main.py
@@ -1,7 +1,6 @@
 """Flask web application for deeposlandia
 """
 
-from configparser import ConfigParser
 import daiquiri
 from flask import (abort, Flask, jsonify, redirect,
                    render_template, request, send_from_directory, url_for)
@@ -9,24 +8,16 @@ import json
 import logging
 import numpy as np
 import os
+import sys
 from PIL import Image
 from werkzeug.utils import secure_filename
 
-from deeposlandia import utils
+from deeposlandia import config, utils
 from deeposlandia.inference import predict
 
 
 logger = daiquiri.getLogger(__name__)
 
-
-_DEEPOSL_CONFIG = os.getenv('DEEPOSL_CONFIG')
-_DEEPOSL_CONFIG = _DEEPOSL_CONFIG if _DEEPOSL_CONFIG is not None else "config.ini"
-config = ConfigParser()
-if os.path.isfile(_DEEPOSL_CONFIG):
-    config.read(_DEEPOSL_CONFIG)
-else:
-    logger.error("No file config.ini!")
-    sys.exit(1)
 
 PROJECT_FOLDER = config.get("folder", "project_folder")
 UPLOAD_FOLDER = os.path.join(PROJECT_FOLDER, 'uploads/')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -174,8 +174,10 @@ def aerial_nb_images():
 
 
 @pytest.fixture
-def aerial_nb_output_images():
-    return aerial_nb_images() * (aerial_test_image_size()/aerial_tile_size()) ** 2
+def aerial_nb_output_images(
+        aerial_nb_images, aerial_test_image_size, aerial_tile_size
+):
+    return aerial_nb_images * (aerial_test_image_size/aerial_tile_size) ** 2
 
 
 @pytest.fixture
@@ -238,9 +240,16 @@ def tanzania_nb_images():
 
 
 @pytest.fixture
-def tanzania_nb_output_images():
-    return (tanzania_nb_images()
-            * math.ceil(tanzania_raw_image_size()/tanzania_image_size())
+def tanzania_nb_output_training_images():
+    return 10
+
+
+@pytest.fixture
+def tanzania_nb_output_testing_images(
+        tanzania_nb_images, tanzania_raw_image_size, tanzania_image_size
+):
+    return (tanzania_nb_images
+            * math.ceil(tanzania_raw_image_size/tanzania_image_size)
             ** 2)
 
 
@@ -250,8 +259,13 @@ def tanzania_nb_labels():
 
 
 @pytest.fixture(scope='session')
-def tanzania_config(tmpdir_factory):
-    return tmpdir_factory.getbasetemp().join('tanzania.json')
+def tanzania_training_config(tmpdir_factory):
+    return tmpdir_factory.getbasetemp().join('tanzania_training.json')
+
+
+@pytest.fixture(scope='session')
+def tanzania_testing_config(tmpdir_factory):
+    return tmpdir_factory.getbasetemp().join('tanzania_testing.json')
 
 
 @pytest.fixture
@@ -274,11 +288,20 @@ def tanzania_raw_sample():
 
 
 @pytest.fixture(scope='session')
-def tanzania_temp_dir(tmpdir_factory):
-    tanzania_subdir = tmpdir_factory.mktemp('tanzania', numbered=False)
-    tmpdir_factory.mktemp('tanzania/images', numbered=False)
-    tmpdir_factory.mktemp('tanzania/labels', numbered=False)
-    tmpdir_factory.mktemp('tanzania/checkpoints', numbered=False)
+def tanzania_training_temp_dir(tmpdir_factory):
+    tanzania_subdir = tmpdir_factory.mktemp('tanzania_training', numbered=False)
+    tmpdir_factory.mktemp('tanzania_training/images', numbered=False)
+    tmpdir_factory.mktemp('tanzania_training/labels', numbered=False)
+    tmpdir_factory.mktemp('tanzania_training/checkpoints', numbered=False)
+    return tanzania_subdir
+
+
+@pytest.fixture(scope='session')
+def tanzania_testing_temp_dir(tmpdir_factory):
+    tanzania_subdir = tmpdir_factory.mktemp('tanzania_testing', numbered=False)
+    tmpdir_factory.mktemp('tanzania_testing/images', numbered=False)
+    tmpdir_factory.mktemp('tanzania_testing/labels', numbered=False)
+    tmpdir_factory.mktemp('tanzania_testing/checkpoints', numbered=False)
     return tanzania_subdir
 
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -6,22 +6,12 @@ import numpy as np
 import os
 import pytest
 
-from deeposlandia.datasets.dataset import Dataset
 from deeposlandia.datasets.shapes import ShapeDataset
 from deeposlandia.datasets.mapillary import MapillaryDataset
 from deeposlandia.datasets.aerial import AerialDataset
 from deeposlandia.datasets.tanzania import TanzaniaDataset
 from deeposlandia.utils import tile_image_correspondance
 
-def test_dataset_creation(mapillary_image_size):
-    """Create a generic dataset
-    """
-    d = Dataset(mapillary_image_size)
-    assert d.image_size == mapillary_image_size
-    assert d.get_nb_labels() == 0
-    assert d.get_nb_images() == 0
-    d.add_label(label_id=0, label_name="test_label", color=[100, 100, 100], is_evaluate=True)
-    assert d.get_nb_labels() == 1
 
 def test_mapillary_dataset_creation(mapillary_image_size, mapillary_nb_labels,
     mapillary_input_config):
@@ -31,6 +21,7 @@ def test_mapillary_dataset_creation(mapillary_image_size, mapillary_nb_labels,
     assert d.image_size == mapillary_image_size
     assert d.get_nb_labels(see_all=True) == mapillary_nb_labels
     assert d.get_nb_images() == 0
+
 
 def test_mapillary_dataset_population(mapillary_image_size,
                                       mapillary_raw_sample,
@@ -48,6 +39,7 @@ def test_mapillary_dataset_population(mapillary_image_size,
     assert all(len(os.listdir(os.path.join(str(mapillary_temp_dir), tmp_dir))) == mapillary_nb_images
                for tmp_dir in ["images", "labels"])
 
+
 def test_mapillary_dataset_population_without_labels(mapillary_image_size, mapillary_input_config,
                                                      mapillary_sample_without_labels_dir,
                                                      mapillary_nb_images, mapillary_temp_dir):
@@ -57,6 +49,7 @@ def test_mapillary_dataset_population_without_labels(mapillary_image_size, mapil
     with pytest.raises(FileNotFoundError) as excinfo:
         d.populate(str(mapillary_temp_dir), mapillary_sample_without_labels_dir, nb_images=mapillary_nb_images)
     assert str(excinfo.value).split(':')[0] == "[Errno 2] No such file or directory"
+
 
 def test_mapillary_dataset_loading(mapillary_image_size, mapillary_nb_images,
                                    mapillary_input_config, mapillary_nb_labels,
@@ -70,6 +63,7 @@ def test_mapillary_dataset_loading(mapillary_image_size, mapillary_nb_images,
     assert d.get_nb_labels() == mapillary_nb_labels
     assert d.get_nb_images() == mapillary_nb_images
 
+
 def test_shape_dataset_creation(shapes_image_size, shapes_nb_labels):
     """Create a Shapes dataset
     """
@@ -77,6 +71,7 @@ def test_shape_dataset_creation(shapes_image_size, shapes_nb_labels):
     assert d.image_size == shapes_image_size
     assert d.get_nb_labels() == shapes_nb_labels
     assert d.get_nb_images() == 0
+
 
 def test_shape_dataset_population(shapes_image_size, shapes_nb_images, shapes_nb_labels,
                                   shapes_config, shapes_temp_dir):
@@ -90,6 +85,7 @@ def test_shape_dataset_population(shapes_image_size, shapes_nb_images, shapes_nb
     assert os.path.isfile(str(shapes_config))
     assert all(len(os.listdir(os.path.join(str(shapes_temp_dir), tmp_dir))) == shapes_nb_images
                for tmp_dir in ["images", "labels"])
+
 
 def test_shape_dataset_loading(shapes_image_size, shapes_nb_images, shapes_nb_labels, shapes_sample_config):
     """Load images into a Shapes dataset
@@ -109,10 +105,11 @@ def test_aerial_dataset_creation(aerial_image_size, aerial_tile_size,
     assert d.get_nb_labels() == aerial_nb_labels
     assert d.get_nb_images() == 0
 
-def test_aerial_dataset_population(aerial_tile_size, aerial_temp_dir,
-                                   aerial_raw_sample, aerial_nb_images,
-                                   aerial_config, aerial_nb_labels,
-                                   aerial_nb_output_images):
+def test_aerial_dataset_population(
+        aerial_tile_size, aerial_temp_dir,
+        aerial_raw_sample, aerial_nb_images,
+        aerial_config, aerial_nb_labels, aerial_nb_output_images
+):
     """Populate a AerialImage dataset
     """
     d = AerialDataset(aerial_tile_size)
@@ -125,8 +122,10 @@ def test_aerial_dataset_population(aerial_tile_size, aerial_temp_dir,
     assert all(len(os.listdir(os.path.join(str(aerial_temp_dir), tmp_dir))) == aerial_nb_output_images
                for tmp_dir in ["images", "labels"])
 
-def test_aerial_dataset_loading(aerial_tile_size, aerial_config,
-                                aerial_nb_labels, aerial_nb_output_images):
+def test_aerial_dataset_loading(
+        aerial_tile_size, aerial_config,
+        aerial_nb_labels, aerial_nb_output_images
+):
     """Load images into a AerialImage dataset
     """
     d = AerialDataset(aerial_tile_size)
@@ -163,28 +162,56 @@ def test_tanzania_dataset_creation(tanzania_image_size, tanzania_nb_labels):
     assert d.get_nb_labels() == tanzania_nb_labels
     assert d.get_nb_images() == 0
 
-def test_tanzania_dataset_population(tanzania_image_size, tanzania_temp_dir,
-                                     tanzania_raw_sample, tanzania_nb_images,
-                                     tanzania_config, tanzania_nb_labels,
-                                     tanzania_nb_output_images):
+
+def test_tanzania_training_dataset_population(
+        tanzania_image_size, tanzania_training_temp_dir,
+        tanzania_raw_sample, tanzania_nb_images,
+        tanzania_training_config, tanzania_nb_labels,
+        tanzania_nb_output_training_images
+):
     """Populate a Tanzania dataset
     """
     d = TanzaniaDataset(tanzania_image_size)
-    d.populate(str(tanzania_temp_dir), tanzania_raw_sample,
+    d.populate(str(tanzania_training_temp_dir), tanzania_raw_sample,
                nb_images=tanzania_nb_images)
-    d.save(str(tanzania_config))
+    d.save(str(tanzania_training_config))
     assert d.get_nb_labels() == tanzania_nb_labels
-    assert d.get_nb_images() == tanzania_nb_output_images
-    assert os.path.isfile(str(tanzania_config))
-    assert all(len(os.listdir(os.path.join(str(tanzania_temp_dir), tmp_dir))) == tanzania_nb_output_images
-               for tmp_dir in ["images", "labels"])
+    assert d.get_nb_images() >= 0.1 * tanzania_nb_output_training_images
+    assert d.get_nb_images() <= tanzania_nb_output_training_images + 3
+    assert os.path.isfile(str(tanzania_training_config))
+    assert all(
+        len(os.listdir(os.path.join(str(tanzania_training_temp_dir), tmp_dir)))
+        == d.get_nb_images()
+        for tmp_dir in ["images", "labels"]
+    )
 
-def test_tanzania_dataset_loading(tanzania_image_size, tanzania_config,
-                                  tanzania_nb_labels,
-                                  tanzania_nb_output_images):
+
+def test_tanzania_testing_dataset_population(
+        tanzania_image_size, tanzania_testing_temp_dir,
+        tanzania_raw_sample, tanzania_nb_images,
+        tanzania_testing_config, tanzania_nb_labels,
+        tanzania_nb_output_testing_images
+):
+    """Populate a Tanzania dataset
+    """
+    d = TanzaniaDataset(tanzania_image_size)
+    d.populate(str(tanzania_testing_temp_dir), tanzania_raw_sample,
+               nb_images=tanzania_nb_images, labelling=False)
+    d.save(str(tanzania_testing_config))
+    assert d.get_nb_labels() == tanzania_nb_labels
+    assert d.get_nb_images() == tanzania_nb_output_testing_images
+    assert os.path.isfile(str(tanzania_testing_config))
+    assert len(os.listdir(os.path.join(str(tanzania_testing_temp_dir),
+        "images"))) == d.get_nb_images()
+
+
+def test_tanzania_testing_dataset_loading(
+        tanzania_image_size, tanzania_testing_config,
+        tanzania_nb_labels, tanzania_nb_output_testing_images
+):
     """Load images into a Tanzania dataset
     """
     d = TanzaniaDataset(tanzania_image_size)
-    d.load(tanzania_config)
+    d.load(tanzania_testing_config)
     assert d.get_nb_labels() == tanzania_nb_labels
-    assert d.get_nb_images() == tanzania_nb_output_images
+    assert d.get_nb_images() == tanzania_nb_output_testing_images


### PR DESCRIPTION
This PR introduces more flexibility in dataset population process.

From now, its multiprocessing behavior may be controlled, in the sense that the number of used processes becomes a `populate()` method parameter. The method is called in `deeposlandia/datagen.py`, where one retrieve the number of processes starting from the project configuration file.

Talking about the configuration file, it is now managed in `deeposlandia\__init__.py`, as it is used by the webapp and by the datasets.

Finally, a refactoring of unit tests contained into `tests/test_dataset.py` has been done: one distinguishes now between training and testing datasets when focusing on the Tanzania dataset, as PR #101 modifies its population process. Then the `population(.)` method is run without multiprocessing during the unit tests : some tests fail with it in a fairly mysterious manner...