### PR TITLE
webapp: add information about GDPR

### DIFF
--- a/deeposlandia/webapp/static/app.css
+++ b/deeposlandia/webapp/static/app.css
@@ -96,3 +96,10 @@ __________________________________________________ */
     display: inline-block;
     font-size: small;
 }
+
+.infoframe {
+    background-color:#dddddd;
+    border:1px groove black;
+    border-radius: 5px;
+    padding: 10px;
+}

--- a/deeposlandia/webapp/templates/predictor.html
+++ b/deeposlandia/webapp/templates/predictor.html
@@ -89,7 +89,7 @@
 	</div>
       </div>
     </div>
-    
+
   </div>
 </div>
 
@@ -131,6 +131,20 @@
     <li>void: own vehicle or unlabeled pixels</li>
   </ul>
 </p>
+
+<div class=infoframe>
+  <h4>GPDR compliance</h4>
+  <p>
+    The images are stored on our server when the uploading action is done. We
+    do not use them in any other purpose than this web
+    application. However we commit to delete the uploaded images on a
+    regular basis (<emph>i.e.</emph> each two weeks).
+  </p>
+  <p>
+    The "try-it-yourself" usage implies that the user agrees the terms
+    associated to the transmitted images.
+  </p>
+</div>
 
 {% endblock %}
 


### PR DESCRIPTION
A small text frame has been added at the end of the "Try-It-Yourself" webpage, as the users upload images and must be informed about transmission details.

A GDPR + english review is welcome!

fix #114 