### PR TITLE
Postprocess aerial images

### DIFF
--- a/deeposlandia/datasets/__init__.py
+++ b/deeposlandia/datasets/__init__.py
@@ -24,7 +24,7 @@ logger = daiquiri.getLogger(__name__)
 AVAILABLE_DATASETS = [
     'shapes', 'mapillary', 'aerial', 'tanzania'
 ]
-
+GEOGRAPHIC_DATASETS = ["aerial", "tanzania"]
 
 class Dataset(metaclass=abc.ABCMeta):
     """Generic class that describes the behavior of a Dataset object: it is initialized at least

--- a/deeposlandia/postprocess.py
+++ b/deeposlandia/postprocess.py
@@ -1,0 +1,436 @@
+"""Post-process predicted aerial tiles in order to rebuild complete high
+resolution image.
+
+Do inference on test images starting from a trained model and Keras API. Then
+handle geographic datasets with dedicated libraries (GDAL, geopandas, shapely)
+"""
+
+import argparse
+import glob
+import os
+import sys
+
+import daiquiri
+from osgeo import gdal
+import numpy as np
+from PIL import Image
+
+from keras.models import Model
+import keras.backend as K
+
+from deeposlandia import utils
+from deeposlandia.datasets import GEOGRAPHIC_DATASETS
+from deeposlandia.semantic_segmentation import SemanticSegmentationNetwork
+
+
+logger = daiquiri.getLogger(__name__)
+
+
+def add_program_arguments(parser):
+    """Add instance-specific arguments from the command line
+
+    Parameters
+    ----------
+    parser : argparse.ArgumentParser
+        Input parser
+
+    Returns
+    -------
+    argparse.ArgumentParser
+        Modified parser, with additional arguments
+    """
+    parser.add_argument('-b', '--batch-size', type=int,
+                        help=("Number of images in each inference batch"))
+    parser.add_argument('-D', '--dataset',
+                        required=True, choices=GEOGRAPHIC_DATASETS,
+                        help=("Dataset type (to be chosen amongst available"
+                              " geographic datasets)"))
+    parser.add_argument('-i', '--image-basename',
+                        required=True,
+                        help="Basename of the image within the dataset")
+    parser.add_argument('-p', '--datapath',
+                        default="./data",
+                        help="Relative path towards data directory")
+    parser.add_argument('-s', '--image-size',
+                        required=True, type=int,
+                        help="Image patch size, in pixels")
+    return parser
+
+
+def get_image_paths(datapath, dataset, image_size, image_basename):
+    """Returns a list with the path of every image that belongs to the
+    `dataset`, preprocessed in `image_size`-pixelled images, that were
+    extracted from an original image named as `image_basename`.
+
+    Parameters
+    ----------
+    datapath : str
+        Path of the data on the file system
+    dataset : str
+        Name of the dataset
+    image_size : int
+        Size of preprocessed images, in pixels
+    image_basename : str
+        Original image name
+
+    Returns
+    -------
+    list
+        List of image full paths
+    """
+    image_raw_paths = os.path.join(
+        datapath, dataset, "preprocessed", str(image_size) + "_full",
+        "testing", "images", image_basename + "*"
+    )
+    return [glob.glob(f) for f in [image_raw_paths]][0]
+
+
+def extract_images(image_paths):
+    """Convert a list of image filenames into a numpy array that contains the
+    image data
+
+    Parameters
+    ----------
+    image_paths : str
+        Name of the image files onto the file system
+
+    Returns
+    -------
+    np.array
+        Data that is contained into the image
+    """
+    x_test = []
+    for image_path in image_paths:
+        image = Image.open(image_path)
+        if image.size[0] != image.size[1]:
+            logger.error(("One of the parsed images "
+                          "has non-squared dimensions."))
+            sys.exit(1)
+        x_test.append(np.array(image))
+    return np.array(x_test)
+
+
+def get_labels(datapath, dataset, tile_size):
+    """Extract labels from the `dataset` glossary, according to the
+    preprocessed version of the dataset
+
+    Parameters
+    ----------
+    datapath : str
+        Path of the data on the file system
+    dataset : str
+        Name of the dataset
+    tile_size : int
+        Size of preprocessed images, in pixels
+
+    Returns
+    -------
+    list
+        List of dictionnaries that describes the dataset labels
+    """
+    prepro_folder = utils.prepare_preprocessed_folder(
+        datapath, dataset, tile_size, "full"
+    )
+    if os.path.isfile(prepro_folder["testing_config"]):
+        test_config = utils.read_config(prepro_folder["testing_config"])
+    else:
+        raise ValueError(("There is no testing data with the given "
+                          "parameters. Please generate a valid dataset "
+                          "before calling the program."))
+    labels = [l for l in test_config["labels"] if l["is_evaluate"]]
+    return labels
+
+
+def get_trained_model(datapath, dataset, image_size, nb_labels):
+    """Recover model weights stored on the file system, and assign them into
+    the `model` structure
+
+    Parameters
+    ----------
+    datapath : str
+        Path of the data on the file system
+    dataset : str
+        Name of the dataset
+    image_size : int
+        Image size, in pixels (height=width)
+    nb_labels : int
+        Number of output labels
+
+    Returns
+    -------
+    keras.models.Model
+        Convolutional neural network
+    """
+    K.clear_session()
+    net = SemanticSegmentationNetwork(
+        network_name="semseg_postprocessing",
+        image_size=image_size,
+        nb_labels=nb_labels,
+        dropout=1.0,
+        architecture="unet"
+    )
+    model = Model(net.X, net.Y)
+    output_folder = utils.prepare_output_folder(
+        datapath, dataset, "semantic_segmentation"
+    )
+    checkpoint_filename = "best-model-" + str(image_size) + "-full" + ".h5"
+    checkpoint_full_path = os.path.join(output_folder, checkpoint_filename)
+    if os.path.isfile(checkpoint_full_path):
+        model.load_weights(checkpoint_full_path)
+        logger.info("Model weights have been recovered from %s"
+                    % checkpoint_full_path)
+    else:
+        logger.info(("No available trained model for this image size"
+                     " with optimized hyperparameters. The "
+                     "inference will be done on an untrained model"))
+    return model
+
+
+def assign_label_colors(predicted_labels, labels):
+    """Transform raw Keras prediction into an exploitable numpy array that
+    contains label IDs
+
+    Parameters
+    ----------
+    predicted_labels : numpy.array
+        Output of the prediction process, of shape (img_size, img_size)
+    labels : list
+        List of dictionnaries that describes the dataset labels
+
+    Returns
+    -------
+    numpy.array
+        Coloured predicted labels, of shape (img_size, img_size, 3)
+    """
+    labelled_images = np.zeros(shape=np.append(predicted_labels.shape, 3),
+                               dtype=np.uint8)
+    for i in range(len(labels)):
+        labelled_images[predicted_labels == i] = labels[i]["color"]
+    return labelled_images
+
+
+def extract_coordinates_from_filenames(filenames):
+    """Extract tiled image pixel coordinates starting from their filename, as
+    it enrols the west and north coordinates for tile identification purpose
+
+    Parameters
+    ----------
+    filenames : list
+        List of tiled image filenames
+
+    Returns
+    -------
+    list
+        List of tiled image west and north pixel coordinates, regarding the
+    full original image
+    """
+    basenames = [os.path.splitext(os.path.basename(f))[0] for f in filenames]
+    coordinates = [b.split("_")[-2:] for b in basenames]
+    return [[int(c[0]), int(c[1])] for c in coordinates]
+
+
+def fill_labelled_image(
+        predictions, coordinates, tile_size, img_width, img_height=None
+):
+    """Fill labelled version of the original image with the labelled version of
+    the corresponding tiles
+
+    Parameters
+    ----------
+    predictions : numpy.array
+        Labelled version of tiled images, according to semantic segmentation
+    model predictions
+    coordinates : list
+        List of tiled image west and north pixel coordinates, regarding the
+    full original image
+    tile_size : int
+        Tiled image size, in pixel
+    img_width : int
+        Original image width, in pixel
+    img_height : int
+        Original image height, in pixel
+
+    Returns
+    -------
+    numpy.array
+        Labelled version of the original image, where (i, j)-th pixel value
+    corresponds to its predicted label
+    """
+    img_height = img_height if img_height is not None else img_width
+    extended_width = img_width + tile_size - img_width % tile_size
+    extended_height = img_height + tile_size - img_height % tile_size
+    predicted_image = np.zeros(
+        [extended_height, extended_width],
+        dtype=np.uint8
+    )
+    for coords, image_data in zip(coordinates, predictions):
+        x, y = coords
+        predicted_image[y:y+tile_size, x:x+tile_size] = image_data
+    return predicted_image[:img_height, :img_width]
+
+
+def build_full_labelled_image(
+        images, coordinates, model, tile_size,
+        img_width, img_height=None, batch_size=2
+):
+    """Generate a full labelled version of an image (of shape (`img_width`,
+        `img_height`)), knowing that it was previously splitted in tiles (of
+        size `tile_size`). These tiles are stored on the file system as
+        ̀image_paths`.
+
+    This function includes a semantic segmentation model prediction step. The
+    corresponding `model` is passed as another function argument, as well as
+    the `batch_size` used during inference.
+
+    Parameters
+    ----------
+    images : numpy.array
+        Data associated to tiled images
+    coordinates : list
+        List of tiled image west and north pixel coordinates, regarding the
+    full original image
+    model : keras.models.Model
+        Convolutional neural network
+    tile_size : int
+        Size of the tiled images, in pixel
+    img_width : int
+        Original image width, in pixel
+    img_height : int
+        Original image height, in pixel
+    batch_size : int
+        Number of images passed in each inference batches
+
+    Returns
+    -------
+    numpy.array
+        Labelled version of the original image, where (i, j)-th pixel value
+    corresponds to its predicted label
+    """
+    img_height = img_height if img_height is not None else img_width
+    y_raw_preds = model.predict(images, batch_size=batch_size)
+    predicted_labels = np.argmax(y_raw_preds, axis=3)
+    full_labelled_image = fill_labelled_image(
+        predicted_labels, coordinates, tile_size, img_width, img_height
+    )
+    return full_labelled_image
+
+
+def draw_grid(data, img_width, img_height, tile_size):
+    """Draw a white grid on an original image labelled version, depending on
+    its tile splitting, *i.e.* draw vertical and horizontal lines each
+    `tile_size` pixels.
+
+    Parameters
+    ----------
+    data : numpy.array
+        Labelled version of an image
+    img_width : int
+        Original image width, in pixel
+    img_height : int
+        Original image height, in pixel
+    tile_size : int
+        Size of the tiled images, in pixel
+
+    Returns
+    -------
+    numpy.array
+        Labelled version of an image, with an explicit white grid that
+    highlights the tile splitting
+    """
+    gridded_data = data.copy()
+    for i in range(tile_size, img_width, tile_size):
+        gridded_data[:, i] = np.full([img_height, 3], 255, dtype=np.uint8)
+    for i in range(tile_size, img_height, tile_size):
+        gridded_data[i] = np.full([img_width, 3], 255, dtype=np.uint8)
+    return gridded_data
+
+
+def get_image_features(datapath, dataset, filename):
+    """Retrieve geotiff image features with GDAL
+
+    Use the `GetGeoTransform` method, that provides the following values:
+      + East/West location of Upper Left corner
+      + East/West pixel resolution
+      + 0.0
+      + North/South location of Upper Left corner
+      + 0.0
+      + North/South pixel resolution
+
+    See GDAL documentation (https://www.gdal.org/gdal_tutorial.html)
+
+    Parameters
+    ----------
+    datapath : str
+    dataset : str
+    filename : str
+        Name of the image file from which coordinates are extracted
+
+    Returns
+    -------
+    dict
+        Bounding box of the image (west, south, east, north coordinates), srid,
+    and size (in pixels)
+
+    """
+    input_folder = utils.prepare_input_folder(datapath, dataset)
+    filepath = os.path.join(
+        input_folder, "testing", "images", filename + ".tif"
+    )
+    ds = gdal.Open(filepath)
+    width = ds.RasterXSize
+    height = ds.RasterYSize
+    gt = ds.GetGeoTransform()
+    minx = gt[0]
+    miny = gt[3] + height * gt[5]
+    maxx = gt[0] + width * gt[1]
+    maxy = gt[3]
+    srid = int(ds.GetProjection().split('"')[-2])
+    ds = None
+    return {"west": minx, "south": miny, "east": maxx, "north": maxy,
+            "srid": srid, "width": width, "height": height}
+
+
+if __name__ == '__main__':
+
+    program_description = ("Build a high-resolution image labelling by"
+                           "predicting semantic segmentation labels on "
+                           "image patches, and by postprocessing resulting "
+                           "arrays so as to get geographic entities.")
+    parser = argparse.ArgumentParser(description=program_description)
+    parser = add_program_arguments(parser)
+    args = parser.parse_args()
+
+    features = get_image_features(
+        args.datapath, args.dataset, args.image_basename
+    )
+
+    img_width, img_height = features["width"], features["height"]
+    logger.info("Raw image size: %s, %s" % (img_width, img_height))
+
+    image_paths = get_image_paths(
+        args.datapath, args.dataset, args.image_size, args.image_basename
+    )
+    logger.info("The image will be splitted into %s tiles" % len(image_paths))
+    images = extract_images(image_paths)
+    coordinates = extract_coordinates_from_filenames(image_paths)
+    labels = get_labels(args.datapath, args.dataset, args.image_size)
+
+    model = get_trained_model(
+        args.datapath, args.dataset, args.image_size, len(labels)
+    )
+
+    data = build_full_labelled_image(
+        images, coordinates, model, args.image_size,
+        img_width, img_height, args.batch_size
+    )
+    logger.info("Labelled image dimension: %s, %s"
+                % (data.shape[0], data.shape[1]))
+    coloured_data = assign_label_colors(data, labels)
+    coloured_data = draw_grid(
+        coloured_data, img_width, img_height, args.image_size
+    )
+    Image.fromarray(coloured_data).save(
+        os.path.join(
+            "images", args.image_basename + "_" + str(args.image_size) + ".png"
+        )
+    )

--- a/deeposlandia/postprocess.py
+++ b/deeposlandia/postprocess.py
@@ -101,11 +101,15 @@ def extract_images(image_paths):
     """
     x_test = []
     for image_path in image_paths:
+        if not image_path.endswith(".png"):
+            logger.error("The filename does not refer to an png image.")
+            raise ValueError()
         image = Image.open(image_path)
         if image.size[0] != image.size[1]:
-            logger.error(("One of the parsed images "
-                          "has non-squared dimensions."))
-            sys.exit(1)
+            logger.error(
+                "One of the parsed images has non-squared dimensions."
+            )
+            raise ValueError()
         x_test.append(np.array(image))
     return np.array(x_test)
 

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -28,7 +28,9 @@ def test_extract_coordinates_from_filenames():
 
 
 def test_assign_label_colors():
-    """
+    """Test the label colourization function, that allows to replace label IDs
+    with pixel triplets
+
     """
     labels = [{"name": "foo", "color": [0, 0, 0]},
               {"name": "bar", "color": [200, 200, 200]}]

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -2,29 +2,83 @@
 """
 
 import numpy as np
+import pytest
 
 from deeposlandia import postprocess
 
 
-def test_get_images():
-    """Test the image getting function
+def test_get_image_paths(tanzania_image_size):
+    """Test the image path getting function
 
     Preprocessed image filenames must end with ".png"
     """
-    filenames = postprocess.get_images("./data", "tanzania", 384, "grid_034")
+    filenames = postprocess.get_image_paths(
+        "./tests/data", "tanzania", tanzania_image_size, "grid_066"
+    )
     assert np.all([f.endswith(".png") for f in filenames])
 
 
-def test_extract_coordinates_from_filenames():
-    """Test the x, y coordinates extraction from filenames
+def test_extract_images(tanzania_image_size, tanzania_nb_output_testing_images):
+    """Test the image extraction function, that retrieve the accurate data in a
+    'numpy.array' starting from a list of filenames
 
-    The filename chosen convention is as follows:
-        <path>/<name>_<width>_<height>_<x>_<y>.<extension>
+    This image data must be shaped as (nb_filenames, image_size, image_size, 3).
     """
-    filenames = ["./foofolder/foo_100_100_0_1000.png",
-                 "./barfolder/bar_100_100_2000_2100.png"]
-    coordinates = postprocess.extract_coordinates_from_filenames(filenames)
-    assert np.all(coordinates == [[0, 1000], [2000, 2100]])
+    filenames = postprocess.get_image_paths(
+        "./tests/data", "tanzania", tanzania_image_size, "tanzania_sample"
+    )
+    images = postprocess.extract_images(filenames)
+    assert len(images.shape) == 4
+    assert images.shape[0] == tanzania_nb_output_testing_images
+    assert images.shape[1] == tanzania_image_size
+    assert images.shape[2] == tanzania_image_size
+    assert images.shape[3] == 3
+
+
+def test_get_labels(tanzania_image_size, tanzania_nb_labels):
+    """Test the label retrieving from dataset glossary
+    """
+    labels = postprocess.get_labels(
+        "./tests/data", "tanzania", tanzania_image_size
+    )
+    assert len(labels) == tanzania_nb_labels
+    with pytest.raises(ValueError):
+        postprocess.get_labels(
+            "./elsewhere-on-the-disk", "wrong-dataset", tanzania_image_size
+        )
+
+
+def test_get_trained_model(tanzania_image_size, tanzania_nb_labels):
+    """Test the semantic segmentation model retrieving
+
+    Postprocessing implies getting a 'unet' model (i.e. segmentation
+    segmentation), hence the model must be shaped as follows:
+    - an input layer of shape (None, image_size, image_size, 3)
+    - an output layer of shape (None, image_size, image_size, nb_labels)
+    - 69 hidden layers, amonst which:
+      + 57 are related to convolution
+      + 8 are related to upsampling
+      + 4 are related to pooling
+    """
+    model = postprocess.get_trained_model(
+        "./tests.data", "tanzania", tanzania_image_size, tanzania_nb_labels
+    )
+    assert model.input_shape[1:] == (
+        tanzania_image_size, tanzania_image_size, 3
+    )
+    assert model.output_shape[1:] == (
+        tanzania_image_size, tanzania_image_size, tanzania_nb_labels
+    )
+    model_input_layer = [ml for ml in model.layers if "input" in ml.name]
+    assert len(model_input_layer) == 1
+    model_output_layer = [ml for ml in model.layers if "output" in ml.name]
+    assert len(model_output_layer) == 1
+    model_conv_layers = [ml for ml in model.layers if "conv" in ml.name]
+    assert len(model_conv_layers) == 57
+    model_up_layers = [ml for ml in model.layers if "up" in ml.name]
+    assert len(model_up_layers) == 8
+    model_pool_layers = [ml for ml in model.layers if "pool" in ml.name]
+    assert len(model_pool_layers) == 4
 
 
 def test_assign_label_colors():
@@ -49,6 +103,17 @@ def test_assign_label_colors():
     l2 = postprocess.assign_label_colors(y, labels)
     assert np.all(l1 == l2)
 
+
+def test_extract_coordinates_from_filenames():
+    """Test the x, y coordinates extraction from filenames
+
+    The filename chosen convention is as follows:
+        <path>/<name>_<width>_<height>_<x>_<y>.<extension>
+    """
+    filenames = ["./foofolder/foo_100_100_0_1000.png",
+                 "./barfolder/bar_100_100_2000_2100.png"]
+    coordinates = postprocess.extract_coordinates_from_filenames(filenames)
+    assert np.all(coordinates == [[0, 1000], [2000, 2100]])
 
 
 def test_fill_labelled_image():
@@ -153,3 +218,89 @@ def test_fill_labelled_image_different_sizes():
     )
     e2 = postprocess.fill_labelled_image(tiles, coordinates, 2, 4, 6)
     assert np.all(e1 == e2)
+
+
+def test_build_full_labelled_image(
+        tanzania_image_size, tanzania_nb_labels, tanzania_raw_image_size
+):
+    """Test the label prediction on a high-resolution image that has to be
+        tiled during inference process
+
+    The labelled output is composed of label IDs that must corresponds to the
+    dataset glossary, and its shape must equal the original image size.
+    """
+    datapath = "./tests/data"
+    dataset = "tanzania"
+    image_paths = postprocess.get_image_paths(
+        datapath, dataset, tanzania_image_size, "tanzania_sample"
+    )
+    images = postprocess.extract_images(image_paths)
+    coordinates = postprocess.extract_coordinates_from_filenames(image_paths)
+    model = postprocess.get_trained_model(
+        datapath, dataset, tanzania_image_size, tanzania_nb_labels
+    )
+    labelled_image = postprocess.build_full_labelled_image(
+        images, coordinates, model,
+        tile_size=tanzania_image_size,
+        img_width=tanzania_raw_image_size,
+        batch_size=2
+    )
+    assert labelled_image.shape == (
+        tanzania_raw_image_size, tanzania_raw_image_size
+    )
+    assert np.all([
+        ul in range(tanzania_nb_labels) for ul in np.unique(labelled_image)
+    ])
+
+
+def test_draw_grid(tanzania_image_size, tanzania_raw_image_size):
+    """Test the grid drawing on a labelled image
+
+    This function adds white (i.e. (255, 255, 255)) pixels each 'image_size'
+    pixel vertically and horizontally, without modifying the input data shape.
+    """
+    data = np.zeros(
+        [tanzania_raw_image_size, tanzania_raw_image_size, 3],
+        dtype=np.uint8
+    )
+    gridded_data = postprocess.draw_grid(
+        data, tanzania_raw_image_size,
+        tanzania_raw_image_size, tanzania_image_size
+    )
+    assert data.shape == gridded_data.shape
+    expected_colors = np.array([[0, 0, 0], [255, 255, 255]], dtype=np.uint8)
+    colors = np.unique(np.reshape(gridded_data, [-1, 3]), axis=0)
+    assert np.all(colors == expected_colors)
+    expected_white_pixels = int(tanzania_raw_image_size / tanzania_image_size)
+    gridded_line = gridded_data[0]
+    white_horiz_pixels = np.all(gridded_line == [255, 255, 255], axis=1)
+    assert sum(white_horiz_pixels) == expected_white_pixels
+    gridded_column = gridded_data[:, 0]
+    white_vertic_pixels = np.all(gridded_column == [255, 255, 255], axis=1)
+    assert sum(white_vertic_pixels) == expected_white_pixels
+
+
+def test_get_image_features(tanzania_example_image):
+    """Test the image geographic feature recovering:
+    - 'south', 'north', 'west' and 'east' are the image geographic coordinates,
+    hence floating numbers
+    - west is smaller than east
+    - south is smaller than north
+    - srid is an integer geocode
+    - width and height are strictly positive int, as they represent the image
+    size, in pixels
+    """
+    geofeatures = postprocess.get_image_features(
+        "./tests/data", "tanzania", "tanzania_sample"
+    )
+    assert isinstance(geofeatures["south"], float)
+    assert isinstance(geofeatures["north"], float)
+    assert isinstance(geofeatures["east"], float)
+    assert isinstance(geofeatures["west"], float)
+    assert geofeatures["west"] < geofeatures["east"]
+    assert geofeatures["south"] < geofeatures["north"]
+    assert isinstance(geofeatures["srid"], int)
+    assert isinstance(geofeatures["width"], int)
+    assert isinstance(geofeatures["height"], int)
+    assert geofeatures["width"] > 0
+    assert geofeatures["height"] > 0

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -1,0 +1,153 @@
+"""Unit tests dedicated to predicted label postprocessing
+"""
+
+import numpy as np
+
+from deeposlandia import postprocess
+
+
+def test_get_images():
+    """Test the image getting function
+
+    Preprocessed image filenames must end with ".png"
+    """
+    filenames = postprocess.get_images("./data", "tanzania", 384, "grid_034")
+    assert np.all([f.endswith(".png") for f in filenames])
+
+
+def test_extract_coordinates_from_filenames():
+    """Test the x, y coordinates extraction from filenames
+
+    The filename chosen convention is as follows:
+        <path>/<name>_<width>_<height>_<x>_<y>.<extension>
+    """
+    filenames = ["./foofolder/foo_100_100_0_1000.png",
+                 "./barfolder/bar_100_100_2000_2100.png"]
+    coordinates = postprocess.extract_coordinates_from_filenames(filenames)
+    assert np.all(coordinates == [[0, 1000], [2000, 2100]])
+
+
+def test_assign_label_colors():
+    """
+    """
+    labels = [{"name": "foo", "color": [0, 0, 0]},
+              {"name": "bar", "color": [200, 200, 200]}]
+    y = np.array([
+        [[1, 1, 0], [1, 1, 0], [0, 1, 1]],
+        [[0, 1, 1], [0, 0, 0], [0, 1, 1]]
+    ])
+    l1 = np.array([
+        [[[200, 200, 200], [200, 200, 200], [0, 0, 0]],
+         [[200, 200, 200], [200, 200, 200], [0, 0, 0]],
+         [[0, 0, 0], [200, 200, 200], [200, 200, 200]]],
+        [[[0, 0, 0], [200, 200, 200], [200, 200, 200]],
+         [[0, 0, 0], [0, 0, 0], [0, 0, 0]],
+         [[0, 0, 0], [200, 200, 200], [200, 200, 200]]]
+    ])
+    l2 = postprocess.assign_label_colors(y, labels)
+    assert np.all(l1 == l2)
+
+
+
+def test_fill_labelled_image():
+    """Test the numpy full labelled image building
+
+    Work with pixel tables, hence fixtures must be (n, n, 3)-shaped structures
+    """
+    a1 = np.array([[1, 2], [3, 4]], dtype=np.int8)
+    a2 = np.array([[5, 6], [7, 8]], dtype=np.int8)
+    a3 = np.array([[9, 10], [11, 12]], dtype=np.int8)
+    a4 = np.array([[13, 14], [15, 16]], dtype=np.int8)
+    tiles = np.array([a1, a2, a3, a4])
+    x1, y1 = 0, 0
+    x2, y2 = 2, 0
+    x3, y3 = 0, 2
+    x4, y4 = 2, 2
+    coordinates = [[x1, y1], [x2, y2],
+                   [x3, y3], [x4, y4]]
+    e1 = np.array(
+        [[1, 2, 5, 6],
+         [3, 4, 7, 8],
+         [9, 10, 13, 14],
+         [11, 12, 15, 16]],
+        dtype=np.int8
+    )
+    e2 = postprocess.fill_labelled_image(tiles, coordinates, 2, 4)
+    print(e1)
+    print(e2)
+    assert np.all(e1 == e2)
+
+
+def test_fill_labelled_image_incompatible_sizes():
+    """Test the numpy full labelled image building
+
+    Work with pixel tables, hence fixtures must be (n, n, 3)-shaped structures
+
+    This test case corresponds to the situation where raw image dimensions are
+    not multiples of the tile size.
+    """
+    a1 = np.array([[1, 2], [3, 4]], dtype=np.int8)
+    a2 = np.array([[5, 6], [7, 8]], dtype=np.int8)
+    a3 = np.array([[9, 10], [11, 12]], dtype=np.int8)
+    a4 = np.array([[13, 14], [15, 16]], dtype=np.int8)
+    a5 = np.array([[17, 18], [19, 20]], dtype=np.int8)
+    a6 = np.array([[21, 22], [23, 24]], dtype=np.int8)
+    tiles = np.array([a1, a2, a3, a4, a5, a6])
+    x1, y1 = 0, 0
+    x2, y2 = 2, 0
+    x3, y3 = 0, 2
+    x4, y4 = 2, 2
+    x5, y5 = 0, 4
+    x6, y6 = 2, 4
+    coordinates = [[x1, y1], [x2, y2],
+                   [x3, y3], [x4, y4],
+                   [x5, y5], [x6, y6]]
+    e1 = np.array(
+        [[1, 2, 5],
+         [3, 4, 7],
+         [9, 10, 13],
+         [11, 12, 15],
+         [17, 18, 21]],
+        dtype=np.int8
+    )
+    e2 = postprocess.fill_labelled_image(tiles, coordinates, 2, 3, 5)
+    print(e1)
+    print(e2)
+    assert np.all(e1 == e2)
+
+
+def test_fill_labelled_image_different_sizes():
+    """Test the numpy full labelled image building
+
+    Work with label tables, hence fixtures must be (n, n)-shaped structures
+
+    This test case corresponds to the situation where raw image width and height
+    are not equal.
+    """
+    a1 = np.array([[1, 2], [3, 4]], dtype=np.int8)
+    a2 = np.array([[5, 6], [7, 8]], dtype=np.int8)
+    a3 = np.array([[9, 10], [11, 12]], dtype=np.int8)
+    a4 = np.array([[13, 14], [15, 16]], dtype=np.int8)
+    a5 = np.array([[17, 18], [19, 20]], dtype=np.int8)
+    a6 = np.array([[21, 22], [23, 24]], dtype=np.int8)
+    tiles = np.array([a1, a2, a3, a4, a5, a6])
+    x1, y1 = 0, 0
+    x2, y2 = 2, 0
+    x3, y3 = 0, 2
+    x4, y4 = 2, 2
+    x5, y5 = 0, 4
+    x6, y6 = 2, 4
+    coordinates = [[x1, y1], [x2, y2],
+                   [x3, y3], [x4, y4],
+                   [x5, y5], [x6, y6]]
+    e1 = np.array(
+        [[1, 2, 5, 6],
+         [3, 4, 7, 8],
+         [9, 10, 13, 14],
+         [11, 12, 15, 16],
+         [17, 18, 21, 22],
+         [19, 20, 23, 24]],
+        dtype=np.int8
+    )
+    e2 = postprocess.fill_labelled_image(tiles, coordinates, 2, 4, 6)
+    assert np.all(e1 == e2)

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -51,8 +51,8 @@ def test_get_labels(tanzania_image_size, tanzania_nb_labels):
 def test_get_trained_model(tanzania_image_size, tanzania_nb_labels):
     """Test the semantic segmentation model retrieving
 
-    Postprocessing implies getting a 'unet' model (i.e. segmentation
-    segmentation), hence the model must be shaped as follows:
+    Postprocessing implies getting a 'unet' model (i.e. semantic segmentation),
+    hence the model must be shaped as follows:
     - an input layer of shape (None, image_size, image_size, 3)
     - an output layer of shape (None, image_size, image_size, nb_labels)
     - 69 hidden layers, amonst which:
@@ -82,9 +82,8 @@ def test_get_trained_model(tanzania_image_size, tanzania_nb_labels):
 
 
 def test_assign_label_colors():
-    """Test the label colourization function, that allows to replace label IDs
+    """Test the label colorization function, that allows to replace label IDs
     with pixel triplets
-
     """
     labels = [{"name": "foo", "color": [0, 0, 0]},
               {"name": "bar", "color": [200, 200, 200]}]
@@ -92,7 +91,7 @@ def test_assign_label_colors():
         [[1, 1, 0], [1, 1, 0], [0, 1, 1]],
         [[0, 1, 1], [0, 0, 0], [0, 1, 1]]
     ])
-    l1 = np.array([
+    expected_labels = np.array([
         [[[200, 200, 200], [200, 200, 200], [0, 0, 0]],
          [[200, 200, 200], [200, 200, 200], [0, 0, 0]],
          [[0, 0, 0], [200, 200, 200], [200, 200, 200]]],
@@ -100,8 +99,8 @@ def test_assign_label_colors():
          [[0, 0, 0], [0, 0, 0], [0, 0, 0]],
          [[0, 0, 0], [200, 200, 200], [200, 200, 200]]]
     ])
-    l2 = postprocess.assign_label_colors(y, labels)
-    assert np.all(l1 == l2)
+    labels = postprocess.assign_label_colors(y, labels)
+    assert np.all(labels == expected_labels)
 
 
 def test_extract_coordinates_from_filenames():
@@ -140,8 +139,6 @@ def test_fill_labelled_image():
         dtype=np.int8
     )
     e2 = postprocess.fill_labelled_image(tiles, coordinates, 2, 4)
-    print(e1)
-    print(e2)
     assert np.all(e1 == e2)
 
 
@@ -178,8 +175,6 @@ def test_fill_labelled_image_incompatible_sizes():
         dtype=np.int8
     )
     e2 = postprocess.fill_labelled_image(tiles, coordinates, 2, 3, 5)
-    print(e1)
-    print(e2)
     assert np.all(e1 == e2)
 
 


### PR DESCRIPTION
This PR introduces the postprocessing steps associated to semantic segmentation predictions over aerial georeferenced images.

The label inference is done on small image tiles, that must be merged once predicted labels are ready for every tile. As input, we get tiled images and the corresponding predictions. As output, we have a full labelled image directly comparable with original high-resolution image.

In more details a new module that undertake this operation is provided. It is inspired from existing `inference.py` module, however it focuses only on aerial image datasets (`AerialImage` and `Tanzania`, for now) and semantic segmentation models.

Additionally, a full unit test suite is provided along with the new module.

As complementary remarks, one may note that this PR introduces some duplicated code (`get_image_features(.)` appears twice, though it has two different signatures; then some code lines shall be merged between `inference.py` and `postprocess.py`, it may rely on issue #90). I propose to address it in a further PR.