### PR TITLE
train: append existing CSV when saving metric history fix #102

### DIFF
--- a/deeposlandia/paramoptim.py
+++ b/deeposlandia/paramoptim.py
@@ -407,7 +407,7 @@ def run_model(
         monitor="val_loss", patience=10, verbose=1, mode="max"
     )
     csv_logger = callbacks.CSVLogger(
-        os.path.join(output_folder, "training_metrics.csv")
+        os.path.join(output_folder, "training_metrics.csv"), append=True
     )
 
     hist = model.fit_generator(

--- a/deeposlandia/train.py
+++ b/deeposlandia/train.py
@@ -342,7 +342,7 @@ if __name__ == "__main__":
         monitor="val_loss", patience=10, verbose=1, mode="max"
     )
     csv_logger = callbacks.CSVLogger(
-        os.path.join(output_folder, "training_metrics.csv")
+        os.path.join(output_folder, "training_metrics.csv"), append=True
     )
 
     hist = model.fit_generator(


### PR DESCRIPTION
This PR allows to exploit existing training metric history. Now new training period metrics are appended to existing CSV files.

The PR fixes issue #102 .