### PR TITLE
Address RGBA image uploads

### DIFF
--- a/deeposlandia/webapp/main.py
+++ b/deeposlandia/webapp/main.py
@@ -326,17 +326,27 @@ def upload_image():
         logger.info("No selected file")
         return redirect(request.url)
     if fobj and allowed_file(fobj.filename):
+        message_info = ""
         filename = secure_filename(fobj.filename)
         full_filename = os.path.join(app.config["UPLOAD_FOLDER"], filename)
         fobj.save(full_filename)
         target_size = 400
         image = Image.open(full_filename)
         image = image.resize((target_size, target_size))
+        if image.mode == "RGBA":
+            image = Image.merge(mode="RGB", bands=image.split()[:3])
+            message_info = (
+                "Warning: the uploaded image has an alpha channel "
+                "(transparency feature). "
+                "Here we use only RGB channels."
+                )
+            logger.warning(message_info)
         image.save(full_filename)
         return render_template(
             "predictor.html",
             image_name=filename,
             predicted_filename="sample_image/prediction.png",
+            message=message_info
         )
 
 

--- a/deeposlandia/webapp/templates/predictor.html
+++ b/deeposlandia/webapp/templates/predictor.html
@@ -68,6 +68,7 @@
 	       alt="Uploaded image"
 	       title="Uploaded image"
 	       width="100%" height="85%">
+	  <span><font color="orange"><b>{{ message }}</b></font></span>
 	  {% endif %}
 	</div>
       </div>


### PR DESCRIPTION
This commit aims at addressing uploads of four-channeled images onto the web application predictor tool. For now, such RGBA images are saved, and passed to neural network models; however this last step sends a bug, as the model expects `(im_size, im_size, 3)`-shaped images, and gets `(im_size, im_size, 4)`-shaped images.

As a fix, in case of RGBA images, we store only the first three channels and save the image as a RGB picture on the server. A message is also displayed on the webpage to inform the user.

This PR fixes issue #107 .