### PR TITLE
docs: move web application documentation from readme.md to the docs repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ free to visit our [blog](http://oslandia.com/en/blog/). You certainly want to
 discover some of our results in the
 associated [web application](http://data.oslandia.io/deeposlandia):
 
-![Web application homepage](./images/webapp_homepage.png)
-
 # Content
 
 The project contains the following folders:
@@ -87,6 +85,7 @@ Some files document the command use:
 - [Train a model](./docs/training.md)
 - [Infer labels](./docs/inference.md)
 - [Postprocess results for geographic datasets](./docs/postprocess.md)
+- [Run your own web app instance](./docs/webapp.md)
 
 # Supported datasets
 
@@ -161,30 +160,6 @@ This project implies non-commercial use of datasets, anyway we can work with
 the dataset emitters to get commercial licences if it fits your demand. May you
 be interested in any pre-trained models, please contact us at
 infos+data@oslandia.com!
-
-# Flask application
-
-A Flask Web application may be launched locally through
-`deeposlandia/run_webapp.py`. By default, it is launched on `0.0.0.0/7897`.
-
-Some symbolic links are needed to make the application work (in development
-mode):
-+ `deeposlandia/static/sample_images` must contain the sample images, depicted
-  on application homepage as well as in demonstration web pages (before new
-  images are generated).
-+ `deeposlandia/static/shapes` refers to the server-side repository that
-  contains shapes images and their labels.
-+ `deeposlandia/static/mapillary_agg` refers to the server-side repository that
-  contains Mapillary images and their aggregated labels, *i.e.* 13 labels that
-  summarize the content of the 66 native Mapillary labels.
-+ `deeposlandia/static/predicted_images` links to a temporary repository (for
-  instance, `/tmp/deeposlandia/predicted/`) that contains images generated
-  during the app session as well as their corresponding predicted labelled
-  version.
-
-These symlinks are created when the web application is launched. Their name as
-well as their destination are defined in `config.ini`, a config file located on
-the project root.
 
 # License
 

--- a/docs/webapp.md
+++ b/docs/webapp.md
@@ -1,0 +1,33 @@
+# Web application
+
+## Oslandia version
+
+This project allows to visualize some convolutional neural network results
+(*click on the picture to visit and test it!*):
+
+[![Web application homepage](../images/webapp_homepage.png)](http://data.oslandia.io/deeposlandia)
+
+## Make your own version
+
+The Web application is build with `Flask`, 
+A Flask Web application may be launched locally through
+`deeposlandia/run_webapp.py`. By default, it is launched on `0.0.0.0/7897`.
+
+Some symbolic links are needed to make the application work (in development
+mode):
++ `deeposlandia/static/sample_images` must contain the sample images, depicted
+  on application homepage as well as in demonstration web pages (before new
+  images are generated).
++ `deeposlandia/static/shapes` refers to the server-side repository that
+  contains shapes images and their labels.
++ `deeposlandia/static/mapillary_agg` refers to the server-side repository that
+  contains Mapillary images and their aggregated labels, *i.e.* 13 labels that
+  summarize the content of the 66 native Mapillary labels.
++ `deeposlandia/static/predicted_images` links to a temporary repository (for
+  instance, `/tmp/deeposlandia/predicted/`) that contains images generated
+  during the app session as well as their corresponding predicted labelled
+  version.
+
+These symlinks are created when the web application is launched. Their name as
+well as their destination are defined in `config.ini`, a config file located on
+the project root.


### PR DESCRIPTION
Improve the documentation by cleaning the README.md: the aspects relative to the web application are moved to the `docs` repository.
Now the README.md only contains the installation instruction, and image examples from different datasets.