### PR TITLE
Aggregation simplification

### DIFF
--- a/deeposlandia/__main__.py
+++ b/deeposlandia/__main__.py
@@ -30,12 +30,6 @@ def datagen_parser(subparser, reference_func):
     add_dataset_args(parser)
     add_nb_image_args(parser)
     parser.add_argument(
-        "-a",
-        "--aggregate-label",
-        action="store_true",
-        help="Aggregate labels with respect to their categories",
-    )
-    parser.add_argument(
         "-s",
         "--image-size",
         default=256,
@@ -223,8 +217,6 @@ def add_training_args(parser):
     network model training
 
     Such arguments are defined as follows:
-      - "aggregated_label" indicates whether the dataset labels must be
-    aggregated into larger classes
       - "model" gives the problem that is solved, either semantic segmentation
     or feature detection
       - "name" refers to the instance name, for identification on the file
@@ -245,12 +237,6 @@ def add_training_args(parser):
     parser : argparse.ArgumentParser
         Parser that must be "augmented"
     """
-    parser.add_argument(
-        "-a",
-        "--aggregate-label",
-        action="store_true",
-        help="Aggregate labels with respect to their categories",
-    )
     parser.add_argument(
         "-M",
         "--model",

--- a/deeposlandia/datagen.py
+++ b/deeposlandia/datagen.py
@@ -1,16 +1,11 @@
 """Main method to generate new datasets
 
-Example of program calls:
+Example of program call:
 
 * generate 64*64 pixel images from Shapes dataset, 10000 images in the training
   set, 100 in the validation set, 1000 in the testing set::
 
     python deeposlandia/datagen.py -D shapes -s 64 -t 10000 -v 100 -T 1000
-
-* generate 224*224 pixel images from Mapillary dataset, with aggregated
-  labels::
-
-    python deeposlandia/datagen.py -D mapillary -s 224 -a
 
 """
 
@@ -34,20 +29,14 @@ logger = daiquiri.getLogger(__name__)
 
 def main(args):
     # Data path and repository management
-    aggregate_value = "full" if not args.aggregate_label else "aggregated"
     input_folder = utils.prepare_input_folder(args.datapath, args.dataset)
     prepro_folder = utils.prepare_preprocessed_folder(
-        args.datapath, args.dataset, args.image_size, aggregate_value
+        args.datapath, args.dataset, args.image_size
     )
 
     # Dataset creation
     if args.dataset == "mapillary":
-        config_name = (
-            "config.json"
-            if not args.aggregate_label
-            else "config_aggregate.json"
-        )
-        config_path = os.path.join(input_folder, config_name)
+        config_path = os.path.join(input_folder, "config_aggregate.json")
         train_dataset = MapillaryDataset(args.image_size, config_path)
         validation_dataset = MapillaryDataset(args.image_size, config_path)
         test_dataset = MapillaryDataset(args.image_size, config_path)
@@ -93,7 +82,6 @@ def main(args):
                 prepro_folder["training"],
                 input_image_dir,
                 nb_images=args.nb_training_image,
-                aggregate=args.aggregate_label,
                 nb_processes=int(config.get("running", "processes")),
             )
             train_dataset.save(prepro_folder["training_config"])
@@ -116,7 +104,6 @@ def main(args):
                 prepro_folder["validation"],
                 input_image_dir,
                 nb_images=args.nb_validation_image,
-                aggregate=args.aggregate_label,
                 nb_processes=int(config.get("running", "processes")),
             )
             validation_dataset.save(prepro_folder["validation_config"])
@@ -139,7 +126,6 @@ def main(args):
                 prepro_folder["testing"],
                 input_image_dir,
                 nb_images=args.nb_testing_image,
-                aggregate=args.aggregate_label,
                 labelling=False,
                 nb_processes=int(config.get("running", "processes")),
             )

--- a/deeposlandia/datasets/__init__.py
+++ b/deeposlandia/datasets/__init__.py
@@ -431,7 +431,6 @@ class GeoreferencedDataset(Dataset):
         output_dir,
         input_dir,
         nb_images=None,
-        aggregate=False,
         labelling=True,
         nb_processes=1,
     ):
@@ -446,9 +445,6 @@ class GeoreferencedDataset(Dataset):
         nb_images : integer
             Number of images to be considered in the dataset; if None, consider
         the whole repository
-        aggregate : bool
-            Label aggregation parameter, useless for this dataset, but kept for
-        class method genericity
         labelling : boolean
             If True labels are recovered from dataset, otherwise dummy label
         are generated

--- a/deeposlandia/inference.py
+++ b/deeposlandia/inference.py
@@ -62,7 +62,7 @@ def init_model(
         Convolutional neural network
     """
     K.clear_session()
-    if problem == "feature_detection":
+    if problem == "featdet":
         net = FeatureDetectionNetwork(
             network_name=instance_name,
             image_size=image_size,
@@ -70,7 +70,7 @@ def init_model(
             dropout=dropout,
             architecture=network,
         )
-    elif problem == "semantic_segmentation":
+    elif problem == "semseg":
         net = SemanticSegmentationNetwork(
             network_name=instance_name,
             image_size=image_size,
@@ -261,7 +261,7 @@ def predict(
     y_raw_pred = model.predict(images)
 
     result = {}
-    if problem == "feature_detection":
+    if problem == "featdet":
         label_info = [
             (i["category"], utils.GetHTMLColor(i["color"]))
             for i in train_config["labels"]
@@ -272,7 +272,7 @@ def predict(
                 for i, j in zip(label_info, prediction)
             ]
         return result
-    elif problem == "semantic_segmentation":
+    elif problem == "semseg":
         os.makedirs(output_dir, exist_ok=True)
         predicted_labels = np.argmax(y_raw_pred, axis=3)
         encountered_labels = np.unique(predicted_labels)

--- a/deeposlandia/inference.py
+++ b/deeposlandia/inference.py
@@ -94,7 +94,6 @@ def predict(
     dataset,
     problem,
     datapath="./data",
-    aggregate=False,
     name=None,
     network=None,
     batch_size=None,
@@ -117,8 +116,6 @@ def predict(
     `semantic_segmentation`
     datapath : str
         Relative path of dataset repository
-    aggregate : bool
-        Either or not the labels are aggregated
     name : str
         Name of the saved network
     network : str
@@ -150,13 +147,11 @@ def predict(
     images = extract_images(flattened_image_paths)
     model_input_size = images.shape[1]
 
-    aggregate_value = "full" if not aggregate else "aggregated"
     instance_args = [
         name,
         model_input_size,
         network,
         batch_size,
-        aggregate_value,
         dropout,
         learning_rate,
         learning_rate_decay,
@@ -164,7 +159,7 @@ def predict(
     instance_name = utils.list_to_str(instance_args, "_")
 
     prepro_folder = utils.prepare_preprocessed_folder(
-        datapath, dataset, model_input_size, aggregate_value
+        datapath, dataset, model_input_size
     )
 
     if os.path.isfile(prepro_folder["training_config"]):
@@ -361,7 +356,6 @@ def main(args):
         args.dataset,
         args.model,
         args.datapath,
-        args.aggregate_label,
         args.name,
         args.network,
         args.batch_size,

--- a/deeposlandia/train.py
+++ b/deeposlandia/train.py
@@ -106,7 +106,6 @@ def run_model(
     output_folder,
     instance_name,
     image_size,
-    aggregate_value,
     nb_labels,
     nb_epochs,
     nb_training_image,
@@ -136,8 +135,6 @@ def run_model(
         Name of the instance
     image_size : int
         Size of images, in pixel (height=width)
-    aggregate_value : str
-        Label aggregation policy (either `full` or `aggregated`)
     nb_labels : int
         Number of labels into the dataset
     nb_epochs : int
@@ -265,15 +262,13 @@ def run_model(
 
 
 def main(args):
-    aggregate_value = "full" if not args.aggregate_label else "aggregated"
-
     # Grid search
     model_output = []
     for batch_size in args.batch_size:
         logger.info("Generating data with batch of %s images...", batch_size)
         # Data generator building
         prepro_folder = utils.prepare_preprocessed_folder(
-            args.datapath, args.dataset, args.image_size, aggregate_value
+            args.datapath, args.dataset, args.image_size
         )
         nb_labels, train_gen, valid_gen = get_data(
             prepro_folder,
@@ -296,7 +291,6 @@ def main(args):
                 args.image_size,
                 network,
                 batch_size,
-                aggregate_value,
                 dropout,
                 learning_rate,
                 learning_rate_decay,
@@ -314,7 +308,6 @@ def main(args):
                     output_folder,
                     instance_name,
                     args.image_size,
-                    aggregate_value,
                     nb_labels,
                     args.nb_epochs,
                     args.nb_training_image,
@@ -334,7 +327,7 @@ def main(args):
     )
     instance_name = os.path.join(
         output_folder,
-        "best-{}-" + str(args.image_size) + "-" + aggregate_value + ".{}",
+        "best-{}-" + str(args.image_size) + ".{}",
     )
     best_instance["model"].save(instance_name.format("model", "h5"))
     with open(instance_name.format("instance", "json"), "w") as fobj:

--- a/deeposlandia/utils.py
+++ b/deeposlandia/utils.py
@@ -139,7 +139,7 @@ def prepare_input_folder(datapath, dataset):
 
 
 def prepare_preprocessed_folder(
-    datapath, dataset, image_size, aggregate_value
+    datapath, dataset, image_size
 ):
     """Data path and repository management; create all the folders needed to
     accomplish the current instance training/testing
@@ -150,8 +150,6 @@ def prepare_preprocessed_folder(
         Data root directory, contain all used the datasets
     dataset : str
         Dataset name, *e.g.* `mapillary` or `shapes`
-    aggregate_value : str
-        Indicates the label aggregation status, either `full` or `aggregated`
     image_size : int
         Size of the considered images (height and width are equal)
 
@@ -165,7 +163,7 @@ def prepare_preprocessed_folder(
         datapath,
         dataset,
         "preprocessed",
-        str(image_size) + "_" + aggregate_value,
+        str(image_size)
     )
     training_filename = os.path.join(prepro_folder, "training.json")
     validation_filename = os.path.join(prepro_folder, "validation.json")

--- a/deeposlandia/webapp/main.py
+++ b/deeposlandia/webapp/main.py
@@ -19,6 +19,8 @@ from PIL import Image
 from werkzeug.utils import secure_filename
 
 from deeposlandia import config, utils
+from deeposlandia import AVAILABLE_MODELS
+from deeposlandia.datasets import AVAILABLE_DATASETS
 from deeposlandia.inference import predict
 
 
@@ -41,34 +43,30 @@ else:
 app.config["UPLOAD_FOLDER"] = UPLOAD_FOLDER
 app.config["ERROR_404_HELP"] = False
 
-MODELS = ("feature_detection", "semantic_segmentation")
-DATASETS = ("mapillary", "shapes", "aerial", "tanzania")
 ALLOWED_EXTENSIONS = set(["png", "jpg", "jpeg", "tif"])
 
 
 def check_model(model):
-    """Check if `model` is valid, *i.e.* equal to `feature_detection` or
-    `semantic_segmentation`
+    """Check if `model` is valid
 
     Parameters
     ----------
     model : str
         String to verify
     """
-    if model not in MODELS:
+    if model not in AVAILABLE_MODELS:
         abort(404, "Model {} not found".format(model))
 
 
 def check_dataset(dataset):
-    """Check if `dataset` is valid, *i.e.* equal to `shapes`,
-    `mapillary`, `aerial` or `tanzania`
+    """Check if `dataset` is valid
 
     Parameters
     ----------
     dataset : str
         String to verify
     """
-    if dataset not in DATASETS:
+    if dataset not in AVAILABLE_DATASETS:
         abort(404, "Dataset {} not found".format(dataset))
 
 
@@ -173,11 +171,9 @@ def demo_homepage(model, dataset):
     Parameters
     ----------
     model : str
-        Considered research problem (either `feature_detection` or
-    `semantic_segmentation`)
+        Considered research problem
     dataset : str
-        Considered dataset (either `shapes`, `mapillary`, `aerial` or
-    `tanzania`)
+        Considered dataset
 
     Returns
     -------
@@ -206,10 +202,9 @@ def predictor_demo(model, dataset, image):
     Parameters
     ----------
     model : str
-        Considered research problem (either `feature_detection` or
-    `semantic_segmentation`)
+        Considered research problem
     dataset : str
-        Considered dataset (either `shapes` or `mapillary`)
+        Considered dataset
     image : str
         Name of the demo image onto the server
 
@@ -230,12 +225,12 @@ def predictor_demo(model, dataset, image):
         aggregate=agg_value,
         output_dir=PREDICT_FOLDER,
     )
-    if model == "feature_detection":
+    if model == "featdet":
         predicted_image = "sample_image/prediction.png"
         predicted_labels = predictions[
             os.path.join(app.static_folder, image_info["image_file"])
         ]
-    elif model == "semantic_segmentation":
+    elif model == "semseg":
         predicted_image = os.path.join(
             "predicted", image_info["label_file"].split("/")[-1]
         )
@@ -243,8 +238,7 @@ def predictor_demo(model, dataset, image):
     else:
         raise ValueError(
             (
-                "Unknown model, please provide 'feature_detection'"
-                "or 'semantic_segmentation'."
+                "Unknown model, please choose amongst %s.", AVAILABLE_MODELS
             )
         )
     return render_template(
@@ -276,8 +270,7 @@ def prediction():
     predictions = predict(
         [filename],
         "mapillary",
-        "semantic_segmentation",
-        aggregate=True,
+        "semseg",
         output_dir=PREDICT_FOLDER,
     )
     return jsonify(predictions)

--- a/deeposlandia/webapp/main.py
+++ b/deeposlandia/webapp/main.py
@@ -102,21 +102,20 @@ def recover_image_info(dataset, filename):
     version) and label infos
 
     """
-    dataset_code = dataset + "_agg" if dataset == "mapillary" else dataset
-    image_file = os.path.join(dataset_code, "images", filename + ".png")
+    image_file = os.path.join(dataset, "images", filename + ".png")
     label_file = image_file.replace("images", "labels")
-    if dataset == "mapillary" or dataset == "mapillary_agg":
+    if dataset == "mapillary":
         image_file = image_file.replace(".png", ".jpg")
     server_label_filename = os.path.join(app.static_folder, label_file)
     server_label_image = np.array(Image.open(server_label_filename))
     if dataset == "mapillary":
-        size_aggregation = "400_aggregated"
+        image_size = "400"
     elif dataset == "aerial":
-        size_aggregation = "250_full"
+        image_size = "240"
     elif dataset == "tanzania":
-        size_aggregation = "512_full"
+        image_size = "512"
     elif dataset == "shapes":
-        size_aggregation = "64_full"
+        image_size = "64"
     else:
         raise ValueError(
             (
@@ -129,7 +128,7 @@ def recover_image_info(dataset, filename):
             "data",
             dataset,
             "preprocessed",
-            size_aggregation,
+            image_size,
             "validation.json",
         )
     ) as fobj:
@@ -214,15 +213,12 @@ def predictor_demo(model, dataset, image):
         Deep learning model prediction for demo page (depends on the chosen
     model, either feature detection or semantic segmentation)
     """
-    agg_value = dataset == "mapillary"
     logger.info("file: %s, dataset: %s, model: %s", image, dataset, model)
-    agg_value = dataset == "mapillary"
     image_info = recover_image_info(dataset, image)
     predictions = predict(
         [os.path.join(app.static_folder, image_info["image_file"])],
         dataset,
         model,
-        aggregate=agg_value,
         output_dir=PREDICT_FOLDER,
     )
     if model == "featdet":
@@ -357,7 +353,6 @@ def demo_image_selector():
     summarizes the label information for displyaing purpose
     """
     dataset = request.args.get("dataset")
-    dataset_code = dataset + "_agg" if dataset == "mapillary" else dataset
-    server_folder = os.path.join(app.static_folder, dataset_code, "images")
+    server_folder = os.path.join(app.static_folder, dataset, "images")
     filename = np.random.choice(os.listdir(server_folder))
     return jsonify(image_name=filename.split(".")[0])

--- a/deeposlandia/webapp/templates/index.html
+++ b/deeposlandia/webapp/templates/index.html
@@ -31,10 +31,10 @@
 	</div>
         <div class="panel-body">
 	  <p>
-	    <a href="{{ url_for('demo_homepage', model='feature_detection', dataset='mapillary') }}" title="feature detection">
+	    <a href="{{ url_for('demo_homepage', model='featdet', dataset='mapillary') }}" title="feature detection">
 	      <img src="{{url_for('static', filename='sample_image/mapillary_fd.png')}}" width="48%" height="200px">
 	    </a>
-	    <a href="{{ url_for('demo_homepage', model='semantic_segmentation', dataset='mapillary') }}" title="semantic segmentation">
+	    <a href="{{ url_for('demo_homepage', model='semseg', dataset='mapillary') }}" title="semantic segmentation">
 	      <img src="{{url_for('static', filename='sample_image/mapillary_ss.png')}}" width="48%" height="200px">
 	    </a>
 	    <br>Street-scene imagery
@@ -49,10 +49,10 @@
 	</div>
         <div class="panel-body">
 	  <p>
-	    <a href="{{ url_for('demo_homepage', model='feature_detection', dataset='shapes') }}" title="feature detection">
+	    <a href="{{ url_for('demo_homepage', model='featdet', dataset='shapes') }}" title="feature detection">
 	      <img src="{{url_for('static', filename='sample_image/shapes_fd.png')}}" width="48%" height="200px">
 	    </a>
-	    <a href="{{ url_for('demo_homepage', model='semantic_segmentation', dataset='shapes') }}" title="semantic segmentation">
+	    <a href="{{ url_for('demo_homepage', model='semseg', dataset='shapes') }}" title="semantic segmentation">
 	      <img src="{{url_for('static', filename='sample_image/shapes_ss.png')}}" width="48%" height="200px">
 	    </a>
 	    <br>
@@ -68,7 +68,7 @@
 	</div>
         <div class="panel-body">
 	  <p>
-	    <a href="{{ url_for('demo_homepage', model='semantic_segmentation', dataset='aerial') }}" title="semantic segmentation">
+	    <a href="{{ url_for('demo_homepage', model='semseg', dataset='aerial') }}" title="semantic segmentation">
 	      <img src="{{url_for('static', filename='sample_image/aerial_ss.png')}}" width="96%" height="200px">
 	    </a>
 	    <br>Aerial imagery
@@ -83,7 +83,7 @@
 	</div>
         <div class="panel-body">
 	  <p>
-	    <a href="{{ url_for('demo_homepage', model='semantic_segmentation', dataset='tanzania') }}" title="semantic segmentation">
+	    <a href="{{ url_for('demo_homepage', model='semseg', dataset='tanzania') }}" title="semantic segmentation">
 	      <img src="{{url_for('static', filename='sample_image/tanzania_ss.png')}}" width="96%" height="200px">
 	    </a>
 	    <br>Aerial imagery

--- a/deeposlandia/webapp/templates/mapillary_demo.html
+++ b/deeposlandia/webapp/templates/mapillary_demo.html
@@ -63,7 +63,7 @@
 	  <h5>Prediction</h5>
 	</div>
         <div class="panel-body">
-	  {% if model=="feature_detection" %}
+	  {% if model=="featdet" %}
 	  {% for value, proba, color in predicted_labels %}
 	  <span class="color-label" style="background-color: {{ color }}">{{ value }}: {{ proba }}%</span>
 	  {% endfor %}

--- a/deeposlandia/webapp/templates/shapes_demo.html
+++ b/deeposlandia/webapp/templates/shapes_demo.html
@@ -63,7 +63,7 @@
 	  <h5>Prediction</h5>
 	</div>
         <div class="panel-body">
-	  {% if model=="feature_detection" %}
+	  {% if model=="featdet" %}
 	  {% for value, proba, color in predicted_labels %}
 	  <span class="color-label" style="background-color: {{ color }}">{{ value }}: {{ proba }}%</span>
 	  {% endfor %}


### PR DESCRIPTION
This PR aims at simplifying the definition of datasets, by removing the aggregation mode (`aggregated` *vs* `full`). This parameter was introduced in order to design a simpler Mapillary dataset, with less classes. One now considers that the `Mapillary` dataset corresponds to the "aggregated" version, and encourages to modify the dataset name to lighten the preprocessed/output folder structures.

Hence, one may use the following dataset:
- `mapillary` for the aggregated Mapillary dataset
- `mapilfull` for the raw Mapillary dataset
- `mapilbuilding` if focusing only on the building class (respectively to any other class of the dataset).
- ...