### PR TITLE
Assign color to shape

### DIFF
--- a/deeposlandia/postprocess.py
+++ b/deeposlandia/postprocess.py
@@ -440,8 +440,12 @@ def main(args):
     )
     Image.fromarray(colored_data).save(predicted_label_file)
 
-    vectorized_data = geometries.vectorize_mask(data)
-    gdf = gpd.GeoDataFrame({"geometry": vectorized_data})
+    vectorized_labels, vectorized_data = geometries.vectorize_mask(
+        data, colored_data, labels
+    )
+    gdf = gpd.GeoDataFrame(
+        {"labels": vectorized_labels, "geometry": vectorized_data}
+    )
     predicted_geom_folder = os.path.join(
         args.datapath,
         args.dataset,
@@ -454,11 +458,12 @@ def main(args):
         predicted_geom_folder,
         args.image_basename + "_" + str(args.image_size) + ".geojson",
     )
-    if not os.path.isfile(predicted_geom_file):
-        gdf.to_file(predicted_geom_file, driver="GeoJSON")
+    if os.path.isfile(predicted_geom_file):
+        os.remove(predicted_geom_file)
+    gdf.to_file(predicted_geom_file, driver="GeoJSON")
 
     rasterized_data = geometries.rasterize_polygons(
-        vectorized_data, img_height, img_width
+        vectorized_data, vectorized_labels, img_height, img_width
     )
     colored_raster_data = assign_label_colors(rasterized_data, labels)
     colored_raster_data = draw_grid(

--- a/deeposlandia/postprocess.py
+++ b/deeposlandia/postprocess.py
@@ -153,7 +153,7 @@ def get_trained_model(datapath, dataset, image_size, nb_labels):
     output_folder = utils.prepare_output_folder(
         datapath, dataset, "semseg"
     )
-    checkpoint_filename = "best-model-" + str(image_size) + "-full" + ".h5"
+    checkpoint_filename = "best-model-" + str(image_size) + ".h5"
     checkpoint_full_path = os.path.join(output_folder, checkpoint_filename)
     if os.path.isfile(checkpoint_full_path):
         model.load_weights(checkpoint_full_path)


### PR DESCRIPTION
This PR is related to polygon label retrieving during postprocessing. Until now, all the detected objects were of type 1; from now we retrieve the corresponding labels by investigating colors and polygons on the raw predicted image with OpenCV.

The dedicated unit tests have been updated, and new ones have been designed for controlling outputs of newly produced functions.

As a side modification, a remaining occurrence of agregation mode (see PR #134) has been removed in `postprocessing.py`.

This PR fixes #131.