### PR TITLE
Remove all the sys.exit() statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ Les sections conserveront leur nom en anglais.
 
 ### Removed
 
+- `sys.exit` statements (#150)
+
 ## v0.6.1 (2020-04-01)
 
 *Packaging clean-up*

--- a/deeposlandia/__init__.py
+++ b/deeposlandia/__init__.py
@@ -4,7 +4,6 @@
 from configparser import ConfigParser
 import logging
 import os
-import sys
 
 import daiquiri
 
@@ -35,5 +34,4 @@ config = ConfigParser()
 if os.path.isfile(_DEEPOSL_CONFIG):
     config.read(_DEEPOSL_CONFIG)
 else:
-    logger.error("No file config.ini!")
-    sys.exit(1)
+    raise FileNotFoundError("No file config.ini!")

--- a/deeposlandia/datagen.py
+++ b/deeposlandia/datagen.py
@@ -11,7 +11,6 @@ Example of program call:
 
 import argparse
 import os
-import sys
 
 import daiquiri
 import pandas as pd
@@ -66,11 +65,9 @@ def main(args):
         validation_dataset = TanzaniaDataset(args.image_size)
         test_dataset = TanzaniaDataset(args.image_size)
     else:
-        logger.error(
-            "Unsupported dataset type. Please choose amongst %s",
-            AVAILABLE_DATASETS,
+        raise ValueError(
+            f"Unsupported dataset type. Please choose amongst {AVAILABLE_DATASETS}"
         )
-        sys.exit(1)
 
     # Dataset populating/loading
     # (depends on the existence of a specification file)
@@ -137,4 +134,3 @@ def main(args):
     glossary = pd.DataFrame(train_dataset.labels)
     glossary["popularity"] = train_dataset.get_label_popularity()
     logger.info("Data glossary:\n%s", glossary)
-    sys.exit(0)

--- a/deeposlandia/inference.py
+++ b/deeposlandia/inference.py
@@ -16,7 +16,6 @@ Example of program call, that will infers labels on all files from
 import argparse
 import glob
 import os
-import sys
 
 import daiquiri
 import numpy as np
@@ -43,8 +42,7 @@ def init_model(
     Parameters
     ----------
     problem : str
-        Type of solved problem, either `feature_detection` or
-    `semantic_segmentation`
+        Type of solved problem, either `featdet` or `semseg`
     instance_name : str
         Name of the instance, for identification purpose
     image_size : int
@@ -79,13 +77,9 @@ def init_model(
             architecture=network,
         )
     else:
-        logger.error(
-            (
-                "Unrecognized model. Please enter 'feature_detection' "
-                "or 'semantic_segmentation'."
-            )
+        raise ValueError(
+            "Unrecognized model. Please enter 'featdet' or 'semseg'."
         )
-        sys.exit(1)
     return Model(net.X, net.Y)
 
 
@@ -112,8 +106,7 @@ def predict(
     dataset : str
         Name of the dataset
     problem : str
-        Name of the considered model, either `feature_detection` or
-    `semantic_segmentation`
+        Name of the considered model, either `featdet` or `semseg`
     datapath : str
         Relative path of dataset repository
     name : str
@@ -169,14 +162,10 @@ def predict(
         ]
         nb_labels = len(label_ids)
     else:
-        logger.error(
-            (
-                "There is no training data with the given "
-                "parameters. Please generate a valid dataset "
-                "before calling the program."
-            )
+        raise FileNotFoundError(
+            "There is no training data with the given parameters. "
+            "Please generate a valid dataset before calling the program."
         )
-        sys.exit(1)
 
     output_folder = utils.prepare_output_folder(datapath, dataset, problem)
     instance_filename = "best-instance-" + str(model_input_size) + ".json"
@@ -200,11 +189,8 @@ def predict(
         )
     else:
         logger.info(
-            (
-                "No available trained model for this image size"
-                " with optimized hyperparameters. The "
-                "inference will be done on an untrained model"
-            )
+            "No available trained model for this image size with optimized hyperparameters. "
+            "The inference will be done on an untrained model"
         )
 
     y_raw_pred = model.predict(images)
@@ -252,13 +238,9 @@ def predict(
             "label_images": result,
         }
     else:
-        logger.error(
-            (
-                "Unknown model argument. Please use "
-                "'feature_detection' or 'semantic_segmentation'."
-            )
+        raise ValueError(
+                "Unknown model argument. Please use 'featdet' or 'semseg'."
         )
-        sys.exit(1)
 
 
 def summarize_config(config):
@@ -296,10 +278,7 @@ def extract_images(image_paths):
     for image_path in image_paths:
         image = Image.open(image_path)
         if image.size[0] != image.size[1]:
-            logger.error(
-                ("One of the parsed images " "has non-squared dimensions.")
-            )
-            sys.exit(1)
+            raise ValueError("One of the parsed images has non-squared dimensions.")
         x_test.append(np.array(image))
     return np.array(x_test)
 

--- a/deeposlandia/network.py
+++ b/deeposlandia/network.py
@@ -1,8 +1,6 @@
 """Define a class that represents typical convolutional neural networks
 """
 
-import sys
-
 import keras as K
 
 
@@ -39,7 +37,6 @@ class ConvolutionalNeuralNetwork:
                 "per 16. To train a neural network with "
                 "such an input size may fail."
             )
-            sys.exit(1)
         self.network_name = network_name
         self.image_size = image_size
         self.nb_channels = nb_channels

--- a/deeposlandia/train.py
+++ b/deeposlandia/train.py
@@ -6,7 +6,6 @@ from datetime import datetime
 import itertools
 import json
 import os
-import sys
 
 import daiquiri
 import numpy as np
@@ -68,14 +67,10 @@ def get_data(folders, dataset, model, image_size, batch_size):
             seed=SEED,
         )
     else:
-        logger.error(
-            (
-                "There is no training data with the given "
-                "parameters. Please generate a valid dataset "
-                "before calling the training program."
-            )
+        raise FileNotFoundError(
+            "There is no training data with the given parameters. Please "
+            "generate a valid dataset before calling the training program."
         )
-        sys.exit(1)
     if os.path.isfile(folders["validation_config"]):
         validation_generator = generator.create_generator(
             dataset,
@@ -87,14 +82,10 @@ def get_data(folders, dataset, model, image_size, batch_size):
             seed=SEED,
         )
     else:
-        logger.error(
-            (
-                "There is no validation data with the given "
-                "parameters. Please generate a valid dataset "
-                "before calling the training program."
-            )
+        raise FileNotFoundError(
+            "There is no validation data with the given parameters. Please "
+            "generate a valid dataset before calling the training program."
         )
-        sys.exit(1)
     nb_labels = len(label_ids)
     return nb_labels, train_generator, validation_generator
 
@@ -179,13 +170,9 @@ def run_model(
         )
         loss_function = "categorical_crossentropy"
     else:
-        logger.error(
-            (
-                "Unrecognized model: %s. Please choose amongst %s",
-                dl_model, AVAILABLE_MODELS
-            )
+        raise ValueError(
+            f"Unrecognized model: {dl_model}. Please choose amongst {AVAILABLE_MODELS}"
         )
-        sys.exit(1)
     model = Model(net.X, net.Y)
     opt = Adam(lr=learning_rate, decay=learning_rate_decay)
     metrics = ["acc", iou, dice_coef]

--- a/deeposlandia/webapp/main.py
+++ b/deeposlandia/webapp/main.py
@@ -14,7 +14,6 @@ from flask import (
 import json
 import numpy as np
 import os
-import sys
 from PIL import Image
 from werkzeug.utils import secure_filename
 
@@ -38,8 +37,7 @@ if config.get("status", "status") == "dev":
 elif config.get("status", "status") == "prod":
     app = Flask(__name__, static_folder=PROJECT_FOLDER)
 else:
-    logger.error("No defined status, please consider 'dev' or 'prod'.")
-    sys.exit(1)
+    raise ValueError("No defined status, please consider 'dev' or 'prod'.")
 app.config["UPLOAD_FOLDER"] = UPLOAD_FOLDER
 app.config["ERROR_404_HELP"] = False
 

--- a/deeposlandia/webapp/run.py
+++ b/deeposlandia/webapp/run.py
@@ -4,7 +4,6 @@ WARNING: only for development purpose!!
 """
 
 import os
-import sys
 
 import daiquiri
 
@@ -16,8 +15,7 @@ logger = daiquiri.getLogger(__name__)
 
 
 if "symlink" not in config.sections():
-    logger.error("Config.ini file does not contain any 'symlink' section.")
-    sys.exit(1)
+    raise KeyError("Config.ini file does not contain any 'symlink' section.")
 for link_name, path in config.items("symlink"):
     utils.create_symlink(os.path.join(app.static_folder, link_name), path)
 


### PR DESCRIPTION
This PR cleans the code, by removing all the `sys.exit` statements. The `sys.exit(1)` (generally coming with `logger.error` messages) are replaced by error raising.

The `sys.exit(0)` statement in `datagen.py` is removed, as it is completely useless.

Linked issue: #149