### PR TITLE
Introduce progress bar for inference processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Les sections conserveront leur nom en anglais.
 ### Added
 
 - `--nb-tiles-per-image` as a new argument for `datagen` command.
+- A progress bar for inference processes (#153)
 
 ### Changed
 

--- a/deeposlandia/__init__.py
+++ b/deeposlandia/__init__.py
@@ -10,6 +10,11 @@ import daiquiri
 
 __version__ = "0.6.1"
 
+
+# Do not log Tensorflow messages
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
+
+# Configure the logger
 daiquiri.setup(
     level=logging.INFO,
     outputs=(
@@ -25,8 +30,10 @@ daiquiri.setup(
 )
 logger = daiquiri.getLogger("root")
 
+# Deeposlandia supports feature detection (featdet) and semantic segmentation (semseg)
 AVAILABLE_MODELS = ("featdet", "semseg")
 
+# Configuration file handling
 _DEEPOSL_CONFIG = os.getenv("DEEPOSL_CONFIG")
 _DEEPOSL_CONFIG = (
     _DEEPOSL_CONFIG if _DEEPOSL_CONFIG is not None else "config.ini"

--- a/deeposlandia/inference.py
+++ b/deeposlandia/inference.py
@@ -207,7 +207,7 @@ def predict(
             )
         )
 
-    y_raw_pred = model.predict(images)
+    y_raw_pred = model.predict(images, batch_size=2, verbose=1)
 
     result = {}
     if problem == "featdet":

--- a/deeposlandia/postprocess.py
+++ b/deeposlandia/postprocess.py
@@ -297,7 +297,7 @@ def build_full_labelled_image(
     corresponds to its predicted label
     """
     img_height = img_height if img_height is not None else img_width
-    y_raw_preds = model.predict(images, batch_size=batch_size)
+    y_raw_preds = model.predict(images, batch_size=batch_size, verbose=1)
     predicted_labels = np.argmax(y_raw_preds, axis=3)
     full_labelled_image = fill_labelled_image(
         predicted_labels, coordinates, tile_size, img_width, img_height
@@ -391,6 +391,7 @@ def get_image_features(datapath, dataset, filename):
 
 
 def main(args):
+
     features = get_image_features(
         args.datapath, args.dataset, args.image_basename
     )
@@ -410,6 +411,7 @@ def main(args):
         args.datapath, args.dataset, args.image_size, len(labels)
     )
 
+    logger.info("Predict labels for input images...")
     data = build_full_labelled_image(
         images,
         coordinates,


### PR DESCRIPTION
This PR makes us using the `keras` API in order to display progress bar onto the console, when launching inference processes (through `inference.py` or `postprocess.py`).

See the following console logging example:
```
13:11 $ deepo postprocess -D tanzania -b 2 -i grid_034 -s 384
Using TensorFlow backend.
2020-04-30 13:11:48,235 :: INFO :: postprocess :: main : Raw image size: 3850, 3860
2020-04-30 13:11:48,255 :: INFO :: postprocess :: main : The image will be splitted into 121 tiles
2020-04-30 13:11:50,430 :: INFO :: postprocess :: get_trained_model : Model weights have been recovered from ./data/tanzania/output/semseg/checkpoints/best-model-384.h5
2020-04-30 13:11:50,430 :: INFO :: postprocess :: main : Predict labels for input images...
 44/121 [=========>....................] - ETA: 1:29  
```

Linked to #152.