### PR TITLE
Draw the tile grid only if required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Les sections conserveront leur nom en anglais.
 - The preprocessing has been modified for geographic datasets: `-t`, `-v` and `-T` now
   refer to raw images, the amount of preprocessed tiles being obtained by a combination
   of `--nb-tiles-per-image` and these last arguments.
+- The tile grid becomes optional for postprocessing (#155).
 
 ### Fixed
 

--- a/deeposlandia/__main__.py
+++ b/deeposlandia/__main__.py
@@ -133,6 +133,12 @@ def postprocess_parser(subparser, reference_func):
         help=("Number of images in each inference batch"),
     )
     parser.add_argument(
+        "-g",
+        "--draw-grid",
+        action="store_true",
+        help="If specified, draw the grid that materializes the predicted tiles"
+    )
+    parser.add_argument(
         "-i",
         "--image-basename",
         required=True,

--- a/deeposlandia/postprocess.py
+++ b/deeposlandia/postprocess.py
@@ -423,9 +423,10 @@ def main(args):
         "Labelled image dimension: %s, %s" % (data.shape[0], data.shape[1])
     )
     colored_data = assign_label_colors(data, labels)
-    colored_data = draw_grid(
-        colored_data, img_width, img_height, args.image_size
-    )
+    if args.draw_grid:
+        colored_data = draw_grid(
+            colored_data, img_width, img_height, args.image_size
+        )
     predicted_label_folder = os.path.join(
         args.datapath,
         args.dataset,
@@ -466,9 +467,10 @@ def main(args):
         vectorized_data, vectorized_labels, img_height, img_width
     )
     colored_raster_data = assign_label_colors(rasterized_data, labels)
-    colored_raster_data = draw_grid(
-        colored_raster_data, img_width, img_height, args.image_size
-    )
+    if args.draw_grid:
+        colored_raster_data = draw_grid(
+            colored_raster_data, img_width, img_height, args.image_size
+        )
     predicted_raster_folder = os.path.join(
         args.datapath,
         args.dataset,

--- a/docs/postprocess.md
+++ b/docs/postprocess.md
@@ -1,17 +1,18 @@
 # Postprocess geographic dataset predictions
 
-Producing neural network prediction for geographic dataset is interesting
-however the analysis can go further, by converting the predicted raster as
-vectorized data. For example one may run the following command :
+Producing neural network prediction for geographic dataset is interesting however the
+analysis can go further, by converting the predicted raster as vectorized data. For
+example one may run the following command :
 
 ```
-deepo postprocess -P data -D tanzania -s 384 -b 2 -i grid_034
+deepo postprocess -P data -D tanzania -s 384 -b 2 -i grid_034 -g
 ```
 
 It will predict semantic segmentation labels on a file named `grid_034.tif`
-(georeferenced image) located at `./data/tanzania/input/testing/images/`, by
-splitting it in 384x384 pixelled tiles, and making predictions in 2-image
-batchs.
+(georeferenced image) located at `./data/tanzania/input/testing/images/`, by splitting it
+in 384x384 pixelled tiles, and making predictions in 2-image batchs. The `-g` argument,
+if specified, adds a postprocessing grid that materializes the tile within the original
+image.
 
 Model checkpoints, as well as predicted rasters and vectors are stored at
 `./data/tanzania/output/semseg/`.


### PR DESCRIPTION
This PR adds a new CLI argument for postprocessing.

Until now, we have drawn a regular grid on the resulting raster in order to materialize the working tiles. However such a grid is a debugging artefact that won't be necessary in some use cases.

Hence one adds a `-g/--draw-grid` boolean argument, that makes the grid draw optional.