### PR TITLE
Include every output paths into the prepare_output_folder() function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Les sections conserveront leur nom en anglais.
 
 ### Changed
 
+- `utils.prepare_output_folder()` returns now a dictionary of all useful output paths
 - Some dependency updates (Tensorflow, opencv, pillow, keras, daiquiri)
 - The preprocessing has been modified for geographic datasets: `-t`, `-v` and `-T` now
   refer to raw images, the amount of preprocessed tiles being obtained by a combination

--- a/deeposlandia/datasets/__init__.py
+++ b/deeposlandia/datasets/__init__.py
@@ -16,7 +16,7 @@ import numpy as np
 from osgeo import gdal
 from PIL import Image
 
-from deeposlandia import geometries, utils
+from deeposlandia import geometries
 
 logger = daiquiri.getLogger(__name__)
 

--- a/deeposlandia/datasets/shapes.py
+++ b/deeposlandia/datasets/shapes.py
@@ -98,7 +98,7 @@ class ShapeDataset(Dataset):
         output_dir=None,
         input_dir=None,
         nb_images=10000,
-        nb_tiles_per_images=None,
+        nb_tiles_per_image=None,
         aggregate=False,
         labelling=True,
         buf=8,

--- a/deeposlandia/geometries.py
+++ b/deeposlandia/geometries.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 
 import cv2
 import daiquiri
-import fiona
+from fiona.crs import from_epsg
 import geopandas as gpd
 import numpy as np
 import shapely.geometry as shgeom
@@ -265,7 +265,7 @@ def extract_tile_items(
         raster_features, min_x, min_y, tile_width, tile_height
     )
     bdf = gpd.GeoDataFrame(
-        crs=fiona.crs.from_epsg(raster_features["srid"]), geometry=[area]
+        crs=from_epsg(raster_features["srid"]), geometry=[area]
     )
     reproj_labels = labels.to_crs(epsg=raster_features["srid"])
     tile_items = gpd.sjoin(reproj_labels, bdf)

--- a/deeposlandia/inference.py
+++ b/deeposlandia/inference.py
@@ -167,9 +167,8 @@ def predict(
             "Please generate a valid dataset before calling the program."
         )
 
-    output_folder = utils.prepare_output_folder(datapath, dataset, problem)
-    instance_filename = "best-instance-" + str(model_input_size) + ".json"
-    instance_path = os.path.join(output_folder, instance_filename)
+    output_folder = utils.prepare_output_folder(datapath, dataset, model_input_size, problem)
+    instance_path = os.path.join(output_folder, output_folder["best-instance"])
     dropout, network = utils.recover_instance(instance_path)
     model = init_model(
         problem,
@@ -179,13 +178,11 @@ def predict(
         dropout,
         network,
     )
-    checkpoint_filename = "best-model-" + str(model_input_size) + ".h5"
-    checkpoint_full_path = os.path.join(output_folder, checkpoint_filename)
-    if os.path.isfile(checkpoint_full_path):
-        model.load_weights(checkpoint_full_path)
+    if os.path.isfile(output_folder["best-model"]):
+        model.load_weights(output_folder["best-model"])
         logger.info(
             "Model weights have been recovered from %s",
-            checkpoint_full_path,
+            output_folder["best-model"],
         )
     else:
         logger.info(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -171,6 +171,11 @@ def aerial_nb_images():
 
 
 @pytest.fixture
+def nb_tiles_per_image():
+    return 10
+
+
+@pytest.fixture
 def aerial_nb_output_training_images():
     return 10
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -145,6 +145,7 @@ def test_aerial_training_dataset_population(
     aerial_training_temp_dir,
     aerial_raw_sample,
     aerial_nb_images,
+    nb_tiles_per_image,
     aerial_training_config,
     aerial_nb_labels,
     aerial_nb_output_training_images,
@@ -156,6 +157,7 @@ def test_aerial_training_dataset_population(
         str(aerial_training_temp_dir),
         aerial_raw_sample,
         nb_images=aerial_nb_images,
+        nb_tiles_per_image=nb_tiles_per_image,
     )
     d.save(str(aerial_training_config))
     assert d.get_nb_labels() == aerial_nb_labels
@@ -223,6 +225,7 @@ def test_tanzania_training_dataset_population(
     tanzania_training_temp_dir,
     tanzania_raw_sample,
     tanzania_nb_images,
+    nb_tiles_per_image,
     tanzania_training_config,
     tanzania_nb_labels,
     tanzania_nb_output_training_images,
@@ -234,6 +237,7 @@ def test_tanzania_training_dataset_population(
         str(tanzania_training_temp_dir),
         tanzania_raw_sample,
         nb_images=tanzania_nb_images,
+        nb_tiles_per_image=nb_tiles_per_image,
     )
     d.save(str(tanzania_training_config))
     assert d.get_nb_labels() == tanzania_nb_labels

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -127,16 +127,21 @@ def test_output_folder(datapath_repo):
     """
     datapath = str(datapath_repo)
     dataset = "shapes"
+    image_size = 100
     model = "feature_detection"
-    instance_name = "test_instance"
-    prepare_output_folder(datapath, dataset, model, instance_name)
-    assert os.path.isdir(os.path.join(datapath, dataset, "output"))
-    assert os.path.isdir(os.path.join(datapath, dataset, "output", model))
+    output_folder = prepare_output_folder(datapath, dataset, image_size, model)
+    assert len(output_folder.keys()) == 6
     assert os.path.isdir(
         os.path.join(datapath, dataset, "output", model, "checkpoints")
     )
     assert os.path.isdir(
-        os.path.join(
-            datapath, dataset, "output", model, "checkpoints", instance_name
-        )
+        os.path.join(datapath, dataset, "output", model, "predicted_labels")
+    )
+    dataset = "aerial"
+    prepare_output_folder(datapath, dataset, image_size, model)
+    assert os.path.isdir(
+        os.path.join(datapath, dataset, "output", model, "predicted_geometries")
+    )
+    assert os.path.isdir(
+        os.path.join(datapath, dataset, "output", model, "predicted_rasters")
     )

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -1,6 +1,8 @@
 """Unit tests dedicated to predicted label postprocessing
 """
 
+import os
+
 import numpy as np
 import pytest
 
@@ -13,7 +15,7 @@ def test_get_image_paths(tanzania_image_size):
     Preprocessed image filenames must end with ".png"
     """
     filenames = postprocess.get_image_paths(
-        "./tests/data", "tanzania", tanzania_image_size, "grid_066"
+        f"./tests/data/tanzania/preprocessed/{tanzania_image_size}/testing/", "tanzania_sample"
     )
     assert np.all([f.endswith(".png") for f in filenames])
 
@@ -28,7 +30,7 @@ def test_extract_images(
     3).
     """
     filenames = postprocess.get_image_paths(
-        "./tests/data", "tanzania", tanzania_image_size, "tanzania_sample"
+        f"./tests/data/tanzania/preprocessed/{tanzania_image_size}/testing/", "tanzania_sample"
     )
     images = postprocess.extract_images(filenames)
     assert len(images.shape) == 4
@@ -64,7 +66,9 @@ def test_get_trained_model(tanzania_image_size, tanzania_nb_labels):
       + 4 are related to pooling
     """
     model = postprocess.get_trained_model(
-        "./tests.data", "tanzania", tanzania_image_size, tanzania_nb_labels
+        "./tests/data/tanzania/output/semseg/checkpoints/",
+        tanzania_image_size,
+        tanzania_nb_labels
     )
     assert model.input_shape[1:] == (
         tanzania_image_size,
@@ -233,12 +237,16 @@ def test_build_full_labelled_image(
     datapath = "./tests/data"
     dataset = "tanzania"
     image_paths = postprocess.get_image_paths(
-        datapath, dataset, tanzania_image_size, "tanzania_sample"
+        os.path.join(datapath, dataset, "preprocessed", str(tanzania_image_size), "testing"),
+        "tanzania_sample"
     )
     images = postprocess.extract_images(image_paths)
     coordinates = postprocess.extract_coordinates_from_filenames(image_paths)
+    model_filename = f"best-model-{tanzania_image_size}.h5"
     model = postprocess.get_trained_model(
-        datapath, dataset, tanzania_image_size, tanzania_nb_labels
+        os.path.join(datapath, dataset, "output/semseg/checkpoints/", model_filename),
+        tanzania_image_size,
+        tanzania_nb_labels
     )
     labelled_image = postprocess.build_full_labelled_image(
         images,


### PR DESCRIPTION
This PR simplifies the postprocess API, in the sense that we manage the output folders in a similar fashion than the preprocessed folders.

We consider now new output folders:
- `predicted_labels` for model predictions;
- `predicted_geometries` (geographical datasets) for predictions as vectors;
- `predicted_rasters` (geographical datasets) for predictions as rasters.

The model and instance of reference are included in this refactoring.

Concretely, the `prepare_output_folder()` function (`deeposlandia/utils.py`) has been updated and returns now a dictionary.