### PR TITLE
packaging: v0.6.3.post1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Les sections conserveront leur nom en anglais.
 
 ## Unreleased
 
+## v0.6.3.post1 (2020-05-14)
+
+*A nicer Pypi description*
+
+### Fixed
+
+- From `https://github.com/Oslandia/deeposlandia/blob/master/images/...` to `https://github.com/Oslandia/deeposlandia/raw/master/images/...`
+
 ## v0.6.3 (2020-05-14)
 
 *A nice Pypi description*

--- a/deeposlandia/__init__.py
+++ b/deeposlandia/__init__.py
@@ -7,7 +7,7 @@ import os
 
 import daiquiri
 
-__version__ = "0.6.3"
+__version__ = "0.6.3.post1"
 
 
 # Do not log Tensorflow messages


### PR DESCRIPTION
Wrong image paths have been fixed. As an example:
- `https://github.com/Oslandia/deeposlandia/blob/master/images/mapillary_prediction_example.png` leads to the image file on Github;
- `https://github.com/Oslandia/deeposlandia/raw/master/images/mapillary_prediction_example.png` and alternatively `https://raw.githubusercontent.com/Oslandia/deeposlandia/master/images/mapillary_prediction_example.png` leads to the image itself.

Linked to #159 